### PR TITLE
Skip unexported fields

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -749,6 +749,10 @@ func getFieldmap(t reflect.Type) (fm fieldmap, err error) {
 		queue = queue[1:]
 		for j := 0; j < ty.NumField(); j++ {
 			f = ty.Field(j)
+			// skip unexported field
+			if len(f.PkgPath) != 0 {
+				continue
+			}
 			// skip structs which implement `scanner`
 			if f.Type.Kind() == reflect.Struct && !reflect.PtrTo(f.Type).Implements(scanner) {
 				queue = append(queue, f.Type)


### PR DESCRIPTION
skip unexported fields, because any attempt to access those will panic anyway.
