### PR TITLE
Fix for NamedExec panics with unexported fields

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -853,6 +853,11 @@ func getValues(v reflect.Value) []interface{} {
 			isPtr = false
 			isScanner = false
 
+			// skip unexported fields
+			if len(vsf.PkgPath) != 0 {
+				continue
+			}
+
 			// skip duplicate names in the struct tree
 			if _, ok := encountered[vsf.Name]; ok {
 				continue


### PR DESCRIPTION
Fixes panics ("reflect.Value.Interface: cannot return value obtained from unexported field or method") when unexported fields are passed into NamedExec (or BindStruct or getValues). This patch makes the same checks that are made elsewhere (that PkgPath == 0) to ensure that the fields used in NamedExec are actually exported.
