### PR TITLE
Adding support for Oracle named parameters when binding

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -13,6 +13,7 @@ const (
 	UNKNOWN = iota
 	QUESTION
 	DOLLAR
+	NAMED
 )
 
 // BindType returns the bindtype for a given database given a drivername
@@ -24,6 +25,8 @@ func BindType(driverName string) int {
 		return QUESTION
 	case "sqlite":
 		return QUESTION
+	case "oci8":
+		return NAMED
 	}
 	return UNKNOWN
 }
@@ -137,6 +140,9 @@ func BindMap(bindType int, query string, args map[string]interface{}) (string, [
 			// proper bindvar for the bindType
 			arglist = append(arglist, val)
 			switch bindType {
+			case NAMED:
+				rebound = append(rebound, ':')
+				rebound = append(rebound, name...)
 			case QUESTION, UNKNOWN:
 				rebound = append(rebound, '?')
 			case DOLLAR:


### PR DESCRIPTION
Signed-off-by: Adam Kalnas a.kalnas@modcloth.com

This PR adds support for Oracle named place holders. I couldn't add tests around this since they would fail integration (it is difficult to stand up an Oracle DB in CI due to the proprietary nature).

I think we may also need to change the Rebind function, but wanted to open this up to get early feedback before proceeding any further.
