### PR TITLE
Copy the JSON bytes when scanning so they aren't re-used by the driver.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -85,7 +85,7 @@ func (j *JsonText) Scan(src interface{}) error {
 	default:
 		return errors.New("Incompatible type for JsonText")
 	}
-	*j = JsonText(source)
+	*j = JsonText(append((*j)[0:0], source...))
 	return nil
 }
 


### PR DESCRIPTION
When using more than a couple rows, the scan bytes were reused causing incorrect data to be read.
