### PR TITLE
Handle Oracle named parameters in compileNamedQuery

### DIFF
--- a/named.go
+++ b/named.go
@@ -312,9 +312,8 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 			if i == last && unicode.IsOneOf(allowedBindRunes, rune(b)) {
 				name = append(name, b)
 			}
-			// add the string representation to the names list and reset our name buffer
+			// add the string representation to the names list
 			names = append(names, string(name))
-			name = make([]byte, 0, 10)
 			// add a proper bindvar for the bindType
 			switch bindType {
 			// oracle only supports named type bind vars even for positional

--- a/named_test.go
+++ b/named_test.go
@@ -37,12 +37,12 @@ func TestCompileQuery(t *testing.T) {
 	}
 
 	for _, test := range table {
-		qq, names, err := compileNamedQuery([]byte(test.Q), QUESTION)
+		qr, names, err := compileNamedQuery([]byte(test.Q), QUESTION)
 		if err != nil {
 			t.Error(err)
 		}
-		if qq != test.R {
-			t.Errorf("expected %s, got %s", test.R, qq)
+		if qr != test.R {
+			t.Errorf("expected %s, got %s", test.R, qr)
 		}
 		if len(names) != len(test.N) {
 			t.Errorf("expected %#v, got %#v", test.N, names)
@@ -56,6 +56,11 @@ func TestCompileQuery(t *testing.T) {
 		qd, _, _ := compileNamedQuery([]byte(test.Q), DOLLAR)
 		if qd != test.D {
 			t.Errorf("expected %s, got %s", test.D, qd)
+		}
+
+		qq, _, _ := compileNamedQuery([]byte(test.Q), NAMED)
+		if qq != test.Q {
+			t.Errorf("expected %s, got %s", test.Q, qq)
 		}
 	}
 }


### PR DESCRIPTION
Adding to tests as well.

I couldn't determine why we needed to reset the name buffer as that is also done when we encounter a new parameter (`else if b == ':'`), but let me know if I'm missing something.
