### PR TITLE
making LoadFile split a file up on semi-colons

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -1,14 +1,15 @@
 package sqlx
 
 import (
+	"bufio"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
-
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/jmoiron/sqlx/reflectx"
@@ -607,28 +608,59 @@ func Get(q Queryer, dest interface{}, query string, args ...interface{}) error {
 	return r.scanAny(dest, false)
 }
 
-// LoadFile exec's every statement in a file (as a single call to Exec).
+// LoadFile exec's every statement in a file.
 // LoadFile may return a nil *sql.Result if errors are encountered locating or
-// reading the file at path.  LoadFile reads the entire file into memory, so it
-// is not suitable for loading large data dumps, but can be useful for initializing
-// schemas or loading indexes.
-//
-// FIXME: this does not really work with multi-statement files for mattn/go-sqlite3
-// or the go-mysql-driver/mysql drivers;  pq seems to be an exception here.  Detecting
-// this by requiring something with DriverName() and then attempting to split the
-// queries will be difficult to get right, and its current driver-specific behavior
-// is deemed at least not complex in its incorrectness.
+// reading the file at path.
 func LoadFile(e Execer, path string) (*sql.Result, error) {
 	realpath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
-	contents, err := ioutil.ReadFile(realpath)
+	f, err := os.Open(realpath)
 	if err != nil {
 		return nil, err
 	}
-	res, err := e.Exec(string(contents))
-	return &res, err
+	defer f.Close()
+	br := bufio.NewReader(f)
+	re := regexp.MustCompile("^([^\"']|\"[^\"']*\"')*?(;)")
+	var res int64
+	var query string
+	for {
+		line, err := br.ReadString(byte('\n'))
+		if err != nil {
+			break
+		}
+		query += line
+		if re.MatchString(line) {
+			pres, err := e.Exec(query)
+			query = ""
+			if err != nil {
+				return nil, err
+			}
+			rows, err := pres.RowsAffected()
+			if err != nil {
+				return nil, err
+			}
+			res += rows
+		}
+	}
+	var lfr sql.Result
+	if err == nil {
+		lfr = loadFileResult{res}
+	}
+	return &lfr, nil
+}
+
+type loadFileResult struct {
+	rowsAffected int64
+}
+
+func (loadFileResult) LastInsertId() (int64, error) {
+	return 0, errors.New("no LastInsertId available with LoadFile")
+}
+
+func (l loadFileResult) RowsAffected() (int64, error) {
+	return l.rowsAffected, nil
 }
 
 // MustExec execs the query using e and panics if there was an error.


### PR DESCRIPTION
This makes LoadFile() more suitable for doing bulk loads, sending semicolon separated queries. Feedback welcome--I can't think of any problems with it, but I only tested with jackc/pgx and go-cq/cq. Bleh, just realized semi-colons in comments that are in the middle of queries might screw things up, but that doesn't seem like a huge deal. I can fix it if you like the idea of this PR.
