### PR TITLE
Fix #92, add tagNameFunc to handle complicated tag value.

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -35,8 +35,9 @@ func NewMapper(tagName string) *Mapper {
 	}
 }
 
-// NewMapper returns a new mapper which optionally obeys the field tag given
-// by tagName.  If tagName is the empty string, it is ignored.
+// NewMapperTagNameFunc returns a new mapper which optionally obeys a field tag and
+// a tag name mapper func given by f. For each field, the mapped name will be f(tagName, extraParam )
+// if function f is not nil.
 func NewMapperTagNameFunc(tagName string, f func(string, string) string) *Mapper {
 	return &Mapper{
 		cache:          make(map[reflect.Type]fieldMap),
@@ -210,7 +211,7 @@ func apnd(is []int, i int) []int {
 	return x
 }
 
-// getMapping returns a mapping for the t type, using the tagName and the mapFunc
+// getMapping returns a mapping for the t type, using the tagName, tagNameMapFunc and the mapFunc
 // to determine the canonical names of fields.
 func getMapping(t reflect.Type, tagName string, tagNameMapFunc func(string, string) string, mapFunc func(string) string) fieldMap {
 	queue := []typeQueue{}

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -68,6 +68,29 @@ func TestEmbedded(t *testing.T) {
 	}
 }
 
+func TestTagNameMapping(t *testing.T) {
+	type Strategy struct {
+		StrategyId   string `protobuf:"bytes,1,opt,name=strategy_id" json:"strategy_id,omitempty"`
+		StrategyName string
+	}
+
+	m := NewMapperTagNameFunc("json", func(tagName string, value string) string {
+		if strings.Contains(value, ",") {
+			return strings.Split(value, ",")[0]
+		} else {
+			return value
+		}
+	})
+	strategy := Strategy{"1", "Alpah"}
+	mapping := m.TypeMap(reflect.TypeOf(strategy))
+
+	for _, key := range []string{"strategy_id", "StrategyName"} {
+		if _, ok := mapping[key]; !ok {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+}
+
 func TestMapping(t *testing.T) {
 	type Person struct {
 		ID           int


### PR DESCRIPTION
Fix #92, add an extra tagNameFunc to handle complicated tag value. eg. the following struct B have complicated tag values, we can set customized handler function to fetch correct tag values.

```go
// example struct B, have complicated tag value.
type B struct {
       FieldName string `json:"field_name,omitempty"`
       StrategyId  string  `protobuf:"bytes,1,opt,name=strategy_id" json:"strategy_id,omitempty"`
}

func HandleJson(tagName string, value string) string {                                                                                                                             
     if strings.Contains(value, ",") {                                                                                                                                      
         return strings.Split(value, ",")[0]                                                                                                                                
     } else {                                                                                                                                                               
         return value                                                                                                                                                       
     }                                                                                                                                                                      
}

func HandleProtobuf(tagName string, value string) string {     
        ...
}

// handle complicated json
db.Mapper = reflectx.NewMapperTagNameFunc("json", HandleJson)

// handle complicated protobuf
db.Mapper = reflectx.NewMapperTagNameFunc("protobuf", HandleProtobuf)
```
