### PR TITLE
add QueryRow to Queryer interface

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -51,6 +51,7 @@ type ColScanner interface {
 // Queryer is an interface used by Get and Select
 type Queryer interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
 	Queryx(query string, args ...interface{}) (*Rows, error)
 	QueryRowx(query string, args ...interface{}) *Row
 }
@@ -478,6 +479,10 @@ func (q *qStmt) Queryx(query string, args ...interface{}) (*Rows, error) {
 		return nil, err
 	}
 	return &Rows{Rows: r, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}, err
+}
+
+func (q *qStmt) QueryRow(query string, args ...interface{}) *sql.Row {
+	return q.Stmt.QueryRow(args...)
 }
 
 func (q *qStmt) QueryRowx(query string, args ...interface{}) *Row {


### PR DESCRIPTION
I need QueryRow on the Queryer interface for some postgresql specific add ons I'm building in a fork.  Technically I could compose a new interface, but this is much cleaner and since Queryer is public I think it should match up with the available database/sql query methods.

Thanks,

Troy
