### PR TITLE
GetAlloc() function, and MustGetAlloc(), MustSelect() helper functions

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -297,6 +297,11 @@ func (db *DB) Select(dest interface{}, query string, args ...interface{}) error 
 	return Select(db, dest, query, args...)
 }
 
+// Select using this DB, and panic on error.
+func (db *DB) MustSelect(dest interface{}, query string, args ...interface{}) {
+	MustSelect(db, dest, query, args...)
+}
+
 // Get using this DB.
 func (db *DB) Get(dest interface{}, query string, args ...interface{}) error {
 	return Get(db, dest, query, args...)
@@ -628,6 +633,14 @@ func Select(q Queryer, dest interface{}, query string, args ...interface{}) erro
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
 	return scanAll(rows, dest, false)
+}
+
+// Same as Select() except it panics on error.
+func MustSelect(q Queryer, dest interface{}, query string, args ...interface{}) {
+	err := Select(q, dest, query, args...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Get does a QueryRow using the provided Queryer, and scans the resulting row

--- a/sqlx.go
+++ b/sqlx.go
@@ -312,6 +312,7 @@ func (db *DB) GetAlloc(destpp interface{}, query string, args ...interface{}) er
 	return GetAlloc(db, destpp, query, args...)
 }
 
+// Call GetAlloc(), and panic on error
 func (db *DB) MustGetAlloc(destpp interface{}, query string, args ...interface{}) {
 	MustGetAlloc(db, destpp, query, args...)
 }
@@ -429,9 +430,32 @@ func (tx *Tx) Get(dest interface{}, query string, args ...interface{}) error {
 	return Get(tx, dest, query, args...)
 }
 
+// GetAlloc within a transaction.
+func (tx *Tx) GetAlloc(dest interface{}, query string, args ...interface{}) error {
+	return GetAlloc(tx, dest, query, args...)
+}
+
 // MustExec runs MustExec within a transaction.
 func (tx *Tx) MustExec(query string, args ...interface{}) sql.Result {
 	return MustExec(tx, query, args...)
+}
+
+// MustExecOrRollback runs Exec within a transaction. On error it rollbacks the
+// transaction and panics.
+func (tx *Tx) MustExecOrRollback(query string, args ...interface{}) sql.Result {
+	res, err := tx.Exec(query, args...)
+	if err != nil {
+		tx.Rollback()
+		panic(err)
+	}
+	return res
+}
+
+func (tx *Tx) MustCommit() {
+	err := tx.Commit()
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Preparex  a statement within a transaction.

--- a/sqlx.go
+++ b/sqlx.go
@@ -664,6 +664,20 @@ func Get(q Queryer, dest interface{}, query string, args ...interface{}) error {
 // be passed. Results of the query is stored in newly allocated struct, and
 // passed pointer is updated to point to the data. If query results no rows
 // pointer is changed to point to nil.
+//
+// Usage example:
+//   ...
+//   var query = "SELECT ..."
+//   var person *Person
+//
+//   GetAlloc(db, &person, query)
+//
+//   if person == nil {
+//       log.Print("Person not found")
+//   } else {
+//       log.Person("Person is: ", person)
+//   }
+//   ...
 func GetAlloc(q Queryer, destpp interface{}, query string, args ...interface{}) error {
 	t := reflect.TypeOf(destpp)
 

--- a/sqlx.go
+++ b/sqlx.go
@@ -307,6 +307,11 @@ func (db *DB) Get(dest interface{}, query string, args ...interface{}) error {
 	return Get(db, dest, query, args...)
 }
 
+// MustGet using this DB.
+func (db *DB) MustGet(dest interface{}, query string, args ...interface{}) {
+	MustGet(db, dest, query, args...)
+}
+
 // Get using this DB. Result will be stored in a newly allocated struct.
 func (db *DB) GetAlloc(destpp interface{}, query string, args ...interface{}) error {
 	return GetAlloc(db, destpp, query, args...)
@@ -714,6 +719,14 @@ func MustSelect(q Queryer, dest interface{}, query string, args ...interface{}) 
 func Get(q Queryer, dest interface{}, query string, args ...interface{}) error {
 	r := q.QueryRowx(query, args...)
 	return r.scanAny(dest, false)
+}
+
+// MustGet is same as Get but panics on error.
+func MustGet(q Queryer, dest interface{}, query string, args ...interface{}) {
+	err := Get(q, dest, query, args...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Same as Get(), but instead of pointer to interface, duoble pointer should be

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1286,7 +1286,7 @@ func TestGetAlloc(t *testing.T) {
 	RunWithSchema(schema, t, func(db *DB, t *testing.T) {
 		// Returns SQL syntax error
 		err := db.GetAlloc(&sp, errQuery)
-			if err == nil {
+		if err == nil {
 			t.Error("Using invalid SQL should produce an error.")
 		}
 		// Normal request
@@ -1296,8 +1296,8 @@ func TestGetAlloc(t *testing.T) {
 		}
 		// Request with empty result set
 		err = db.GetAlloc(&sp, emptyQuery)
-		if sp != nil {
-			t.Errorf("Got %v, expected %v.", sp, nil)
+		if err != nil || sp != nil {
+			t.Errorf("Got %v (%v), expected %v (%v).", sp, err, nil, nil)
 		}
 	})
 }


### PR DESCRIPTION
I would like to add a new function GetAlloc() to sqlx package.

This function is useful when either 0 or 1 rows should be returned. The idea is to pass a pointer to the destination and this function will set it to nil or the data from DB. For pointer to be modified in the function user should pass a double pointer.

Usage example:
```go
var person *Person

db.GetAlloc(&person, "SELECT ... LIMIT 1")

if person == nil {
    log.Print("Got nothing")
} else {
    log.Print("Got person: ", person)
}
```

Without GetAlloc() user must check for sql.ErrNoRows if using Get() or use slices and Select().

These patches also contain MustGetAlloc() and MustSelect() helper functions to panic on error and tests for GetAlloc().