### PR TITLE
Support embedded maps

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -137,6 +137,9 @@ func FieldByIndexes(v reflect.Value, indexes []int) reflect.Value {
 			alloc := reflect.New(Deref(v.Type()))
 			v.Set(alloc)
 		}
+		if v.Kind() == reflect.Map && v.IsNil() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
 	}
 	return v
 }


### PR DESCRIPTION
If you have an embedded map in a struct, using db.Select() or db.Get() will silently fail to populate the map because the map will set to nil by default when sqlx generates the structs.

For example if you have your data model set up like:
```go
import "database/sql/driver"

type Message struct {
	Text string
	Properties PropertyMap // Stored as JSON in the database
}

type PropertyMap map[string]string

// Implement driver.Valuer and sql.Scanner interfaces on PropertyMap
func (p PropertyMap) Value() (driver.Value, error) {
	if len(p) == 0 {
		return nil, nil
	}
	return json.Marshal(p)
}

func (p PropertyMap) Scan(src interface{}) error {
	v := reflect.ValueOf(src)
	if !v.IsValid() || v.IsNil() {
		return nil
	}
	if data, ok := src.([]byte); ok {
		return json.Unmarshal(data, &p)
	}
	return fmt.Errorf("Could not not decode type %T -> %T", src, p)
}
```
Storing Messages will work correctly, but retrieving them will not work:

```go
m := Message{Text: "hi", Properties: PropertyMap{"color": "blue"}}
db.NamedExec("INSERT INTO messages(text, properties) VALUES (:text, :properties)", m)
// Examining data through psql shows that the message was stored correctly, including the Properties field.
res := []Message{}
db.Select(&res, "SELECT * FROM messages")
fmt.Println(res[0].Properties) // Prints <nil>
```

Currently reflectx.FieldsByIndexes will check if inner struct pointers are nil and generate them as necessary, but not maps.