### PR TITLE
tag handling for reflectx

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -19,11 +19,11 @@ type fieldMap map[string][]int
 // behaves like most marshallers, optionally obeying a field tag for name
 // mapping and a function to provide a basic mapping of fields to names.
 type Mapper struct {
-	cache          map[reflect.Type]fieldMap
-	tagName        string
-	tagNameMapFunc func(string, string) string
-	mapFunc        func(string) string
-	mutex          sync.Mutex
+	cache      map[reflect.Type]fieldMap
+	tagName    string
+	tagMapFunc func(string) string
+	mapFunc    func(string) string
+	mutex      sync.Mutex
 }
 
 // NewMapper returns a new mapper which optionally obeys the field tag given
@@ -35,14 +35,15 @@ func NewMapper(tagName string) *Mapper {
 	}
 }
 
-// NewMapperTagNameFunc returns a new mapper which optionally obeys a field tag and
-// a tag name mapper func given by f. For each field, the mapped name will be f(tagName, extraParam )
-// if function f is not nil.
-func NewMapperTagNameFunc(tagName string, f func(string, string) string) *Mapper {
+// NewMapperTagFunc returns a new mapper which contains a mapper for field names
+// AND a mapper for tag values.  This is useful for tags like json which can
+// have values like "name,omitempty".
+func NewMapperTagFunc(tagName string, mapFunc, tagMapFunc func(string) string) *Mapper {
 	return &Mapper{
-		cache:          make(map[reflect.Type]fieldMap),
-		tagName:        tagName,
-		tagNameMapFunc: f,
+		cache:      make(map[reflect.Type]fieldMap),
+		tagName:    tagName,
+		mapFunc:    mapFunc,
+		tagMapFunc: tagMapFunc,
 	}
 }
 
@@ -63,7 +64,7 @@ func (m *Mapper) TypeMap(t reflect.Type) fieldMap {
 	m.mutex.Lock()
 	mapping, ok := m.cache[t]
 	if !ok {
-		mapping = getMapping(t, m.tagName, m.tagNameMapFunc, m.mapFunc)
+		mapping = getMapping(t, m.tagName, m.mapFunc, m.tagMapFunc)
 		m.cache[t] = mapping
 	}
 	m.mutex.Unlock()
@@ -214,9 +215,9 @@ func apnd(is []int, i int) []int {
 	return x
 }
 
-// getMapping returns a mapping for the t type, using the tagName, tagNameMapFunc and the mapFunc
-// to determine the canonical names of fields.
-func getMapping(t reflect.Type, tagName string, tagNameMapFunc func(string, string) string, mapFunc func(string) string) fieldMap {
+// getMapping returns a mapping for the t type, using the tagName, mapFunc and
+// tagMapFunc to determine the canonical names of fields.
+func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc func(string) string) fieldMap {
 	queue := []typeQueue{}
 	queue = append(queue, typeQueue{Deref(t), []int{}})
 	m := fieldMap{}
@@ -235,8 +236,8 @@ func getMapping(t reflect.Type, tagName string, tagNameMapFunc func(string, stri
 				} else {
 					name = f.Name
 				}
-			} else if tagNameMapFunc != nil {
-				name = tagNameMapFunc(tagName, name)
+			} else if tagMapFunc != nil {
+				name = tagMapFunc(name)
 			}
 
 			// if the name is "-", disabled via a tag, skip it

--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -35,8 +35,9 @@ func NewMapper(tagName string) *Mapper {
 	}
 }
 
-// NewMapper returns a new mapper which optionally obeys the field tag given
-// by tagName.  If tagName is the empty string, it is ignored.
+// NewMapperTagNameFunc returns a new mapper which optionally obeys a field tag and
+// a tag name mapper func given by f. For each field, the mapped name will be f(tagName, extraParam )
+// if function f is not nil.
 func NewMapperTagNameFunc(tagName string, f func(string, string) string) *Mapper {
 	return &Mapper{
 		cache:          make(map[reflect.Type]fieldMap),
@@ -210,7 +211,7 @@ func apnd(is []int, i int) []int {
 	return x
 }
 
-// getMapping returns a mapping for the t type, using the tagName and the mapFunc
+// getMapping returns a mapping for the t type, using the tagName, tagNameMapFunc and the mapFunc
 // to determine the canonical names of fields.
 func getMapping(t reflect.Type, tagName string, tagNameMapFunc func(string, string) string, mapFunc func(string) string) fieldMap {
 	queue := []typeQueue{}

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -68,6 +68,29 @@ func TestEmbedded(t *testing.T) {
 	}
 }
 
+func TestTagNameMapping(t *testing.T) {
+	type Strategy struct {
+		StrategyId   string `protobuf:"bytes,1,opt,name=strategy_id" json:"strategy_id,omitempty"`
+		StrategyName string
+	}
+
+	m := NewMapperTagNameFunc("json", func(tagName string, value string) string {
+		if strings.Contains(value, ",") {
+			return strings.Split(value, ",")[0]
+		} else {
+			return value
+		}
+	})
+	strategy := Strategy{"1", "Alpah"}
+	mapping := m.TypeMap(reflect.TypeOf(strategy))
+
+	for _, key := range []string{"strategy_id", "StrategyName"} {
+		if _, ok := mapping[key]; !ok {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
+}
+
 func TestMapping(t *testing.T) {
 	type Person struct {
 		ID           int

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -74,7 +74,7 @@ func TestTagNameMapping(t *testing.T) {
 		StrategyName string
 	}
 
-	m := NewMapperTagNameFunc("json", func(tagName string, value string) string {
+	m := NewMapperTagFunc("json", strings.ToUpper, func(value string) string {
 		if strings.Contains(value, ",") {
 			return strings.Split(value, ",")[0]
 		} else {
@@ -84,7 +84,7 @@ func TestTagNameMapping(t *testing.T) {
 	strategy := Strategy{"1", "Alpah"}
 	mapping := m.TypeMap(reflect.TypeOf(strategy))
 
-	for _, key := range []string{"strategy_id", "StrategyName"} {
+	for _, key := range []string{"strategy_id", "STRATEGYNAME"} {
 		if _, ok := mapping[key]; !ok {
 			t.Errorf("Expecting to find key %s in mapping but did not.", key)
 		}


### PR DESCRIPTION
Made a few small changes to this PR, which was originally #93 (for #92)

* changed the name of the tag mapper to `tagMapFunc` throughout, as it maps the tag *value* and not the tag name
* cleaned up comments slightly
* altered API to accept two functions, `mapFunc` and `tagMapFunc`, which are both `func (string) string`

I think this way is simpler and flexible.