### PR TITLE
Update ptrs branch

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -143,7 +143,7 @@ func (m *Mapper) FieldByName(v reflect.Value, name string) reflect.Value {
 	return FieldByIndexes(v, fi.Index)
 }
 
-// StructMapByName returns a slice of values corresponding to the slice of names
+// FieldsByName returns a slice of values corresponding to the slice of names
 // for the value.  Panics if v's Kind is not Struct or v is not Indirectable
 // to a struct Kind.  Returns zero Value for each name not found.
 func (m *Mapper) FieldsByName(v reflect.Value, names []string) []reflect.Value {

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -66,7 +66,7 @@ func TestBasicEmbedded(t *testing.T) {
 		t.Errorf("Expecting 5 fields")
 	}
 
-	// for _, fi := range fields.index {
+	// for _, fi := range fields.Index {
 	// 	log.Println(fi)
 	// }
 
@@ -233,9 +233,6 @@ func TestInlineStruct(t *testing.T) {
 	}
 }
 
-// TODO: .. question was.. inline struct mapping.. can this be cached..?
-// *********** what is the performance hit..?
-
 func TestFieldsEmbedded(t *testing.T) {
 	m := NewMapper("db")
 
@@ -348,6 +345,32 @@ func TestPtrFields(t *testing.T) {
 	v = m.FieldByName(pv, "author")
 	if v.Interface().(string) != post.Author {
 		t.Errorf("Expecting %s, got %s", post.Author, v.Interface().(string))
+	}
+}
+
+func TestFieldMap(t *testing.T) {
+	type Foo struct {
+		A int
+		B int
+		C int
+	}
+
+	f := Foo{1, 2, 3}
+	m := NewMapperFunc("db", strings.ToLower)
+
+	fm := m.FieldMap(reflect.ValueOf(f))
+
+	if len(fm) != 3 {
+		t.Errorf("Expecting %d keys, got %d", 3, len(fm))
+	}
+	if fm["a"].Interface().(int) != 1 {
+		t.Errorf("Expecting %d, got %d", 1, ival(fm["a"]))
+	}
+	if fm["b"].Interface().(int) != 2 {
+		t.Errorf("Expecting %d, got %d", 2, ival(fm["b"]))
+	}
+	if fm["c"].Interface().(int) != 3 {
+		t.Errorf("Expecting %d, got %d", 3, ival(fm["c"]))
 	}
 }
 

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -132,12 +132,20 @@ CREATE TABLE nullperson (
     last_name text NULL,
     email text NULL
 );
+
+CREATE TABLE employees (
+	name text,
+	id integer,
+	boss_id integer
+);
+
 `,
 	drop: `
 drop table person;
 drop table place;
 drop table capplace;
 drop table nullperson;
+drop table employees;
 `,
 }
 
@@ -242,6 +250,9 @@ func loadDefaultFixture(db *DB, t *testing.T) {
 	} else {
 		tx.MustExec(tx.Rebind("INSERT INTO capplace (\"COUNTRY\", \"TELCODE\") VALUES (?, ?)"), "Sarf Efrica", "27")
 	}
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id) VALUES (?, ?)"), "Peter", "4444")
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id, boss_id) VALUES (?, ?, ?)"), "Joe", "1", "4444")
+	tx.MustExec(tx.Rebind("INSERT INTO employees (name, id, boss_id) VALUES (?, ?, ?)"), "Martin", "2", "4444")
 	tx.Commit()
 }
 
@@ -401,6 +412,42 @@ func TestEmbeddedStructs(t *testing.T) {
 		// in order to allow for more flexibility in destination structs
 		if err != nil {
 			t.Errorf("Was not expecting an error on embed conflicts.")
+		}
+	})
+}
+
+func TestJoinQuery(t *testing.T) {
+	type Employee struct {
+		Name string
+		Id   int64
+		// BossId is an id into the employee table
+		BossId sql.NullInt64 `db:"boss_id"`
+	}
+	type Boss Employee
+
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+
+		var employees []struct {
+			Employee
+			Boss `db:"boss"`
+		}
+
+		err := db.Select(
+			&employees,
+			`SELECT employees.*, boss.id "boss.id", boss.name "boss.name" FROM employees
+			  JOIN employees AS boss ON employees.boss_id = boss.id`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, em := range employees {
+			if len(em.Employee.Name) == 0 {
+				t.Errorf("Expected non zero lengthed name.")
+			}
+			if em.Employee.BossId.Int64 != em.Boss.Id {
+				t.Errorf("Expected boss ids to match")
+			}
 		}
 	})
 }


### PR DESCRIPTION
I've finished off the reflectx ptrs branch. As far as I'm concerned, this branch is ready for use (we've already been using the earlier versions in production at Pressly).

This PR updates:
1. Renaming field to FieldInfo
2. Renaming fields to StructMap
3. Yes, both FieldInfo and StructMap are exported since we return them from other exported functions. As well, libraries that do struct tag gymnastics can also interact with FieldInfo then
4. Implemented FieldMap method for completeness and added test case
5. Ran benchmarks of master vs ptrs for sqlx and reflectx, and they are almost identical
6. Added a test case and example in sqlx for a join query related to issue #131