### PR TITLE
Refactor and optimize 'In'. Add benchmark.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // Bindvar types supported by Rebind, BindMap and BindStruct.
@@ -92,70 +93,95 @@ func rebindBuff(bindType int, query string) string {
 // and a new arg list that can be executed by a database. The `query` should
 // use the `?` bindVar.  The return value uses the `?` bindVar.
 func In(query string, args ...interface{}) (string, []interface{}, error) {
-	type ra struct {
-		v       reflect.Value
-		t       reflect.Type
-		isSlice bool
-	}
-	ras := make([]ra, 0, len(args))
-	for _, arg := range args {
-		v := reflect.ValueOf(arg)
-		t, _ := baseType(v.Type(), reflect.Slice)
-		ras = append(ras, ra{v, t, t != nil})
+	// argMeta stores reflect.Value and length for slices and
+	// the value itself for non-slice arguments
+	type argMeta struct {
+		v      reflect.Value
+		i      interface{}
+		length int
 	}
 
-	anySlices := false
-	for _, s := range ras {
-		if s.isSlice {
-			anySlices = true
-			if s.v.Len() == 0 {
+	var flatArgsCount, sliceCount int
+
+	meta := make([]argMeta, len(args))
+
+	for i, arg := range args {
+		v := reflect.ValueOf(arg)
+		t, _ := baseType(v.Type(), reflect.Slice)
+
+		if t != nil {
+			meta[i].length = v.Len()
+			meta[i].v = v
+
+			sliceCount++
+			flatArgsCount += meta[i].length
+
+			if meta[i].length == 0 {
 				return "", nil, errors.New("empty slice passed to 'in' query")
 			}
+		} else {
+			meta[i].i = arg
+			flatArgsCount++
 		}
 	}
 
 	// don't do any parsing if there aren't any slices;  note that this means
 	// some errors that we might have caught below will not be returned.
-	if !anySlices {
+	if sliceCount == 0 {
 		return query, args, nil
 	}
 
-	var a []interface{}
-	var buf bytes.Buffer
-	var pos int
+	newArgs := make([]interface{}, 0, flatArgsCount)
 
-	for _, r := range query {
-		if r == '?' {
-			if pos >= len(ras) {
-				// if this argument wasn't passed, lets return an error;  this is
-				// not actually how database/sql Exec/Query works, but since we are
-				// creating an argument list programmatically, we want to be able
-				// to catch these programmer errors earlier.
-				return "", nil, errors.New("number of bindVars exceeds arguments")
-			} else if ras[pos].isSlice {
-				// if this argument is a slice, expand the slice into arguments and
-				// assume that the bindVars should be comma separated.
-				length := ras[pos].v.Len()
-				for i := 0; i < length-1; i++ {
-					buf.Write([]byte("?, "))
-					a = append(a, ras[pos].v.Index(i).Interface())
-				}
-				a = append(a, ras[pos].v.Index(length-1).Interface())
-				buf.WriteRune('?')
-			} else {
-				// a normal argument, procede as normal.
-				a = append(a, args[pos])
-				buf.WriteRune(r)
-			}
-			pos++
-		} else {
-			buf.WriteRune(r)
+	var arg, offset int
+	var buf bytes.Buffer
+
+	for i := strings.IndexByte(query[offset:], '?'); i != -1 && arg < len(meta); i = strings.IndexByte(query[offset:], '?') {
+		argMeta := meta[arg]
+		arg++
+
+		// not a slice, continue.
+		// our questionmark will either be written before the next expansion
+		// of a slice or after the loop when writing the rest of the query
+		if argMeta.length == 0 {
+			offset = offset + i + 1
+			newArgs = append(newArgs, argMeta.i)
+			continue
 		}
+
+		// write everything up to and including our ? character
+		buf.WriteString(query[:offset+i+1])
+
+		newArgs = append(newArgs, argMeta.v.Index(0).Interface())
+
+		for si := 1; si < argMeta.length; si++ {
+			buf.WriteString(", ?")
+			newArgs = append(newArgs, argMeta.v.Index(si).Interface())
+		}
+
+		// slice the query and reset the offset. this avoids some bookkeeping for
+		// the write after the loop
+		query = query[offset+i+1:]
+		offset = 0
 	}
 
-	if pos != len(ras) {
+	buf.WriteString(query)
+
+	if arg < len(meta) {
 		return "", nil, errors.New("number of bindVars less than number arguments")
 	}
 
-	return buf.String(), a, nil
+	// get the result as bytes first, to avoid converting to a string if we return
+	// an error
+	res := buf.Bytes()
+
+	if bytes.Count(res, []byte{'?'}) > flatArgsCount {
+		// if an argument wasn't passed, lets return an error;  this is
+		// not actually how database/sql Exec/Query works, but since we are
+		// creating an argument list programmatically, we want to be able
+		// to catch these programmer errors earlier.
+		return "", nil, errors.New("number of bindVars exceeds arguments")
+	}
+
+	return string(res), newArgs, nil
 }

--- a/bind.go
+++ b/bind.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/jmoiron/sqlx/reflectx"
 )
 
 // Bindvar types supported by Rebind, BindMap and BindStruct.
@@ -107,9 +109,9 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 
 	for i, arg := range args {
 		v := reflect.ValueOf(arg)
-		t, _ := baseType(v.Type(), reflect.Slice)
+		t := reflectx.Deref(v.Type())
 
-		if t != nil {
+		if t.Kind() == reflect.Slice {
 			meta[i].length = v.Len()
 			meta[i].v = v
 

--- a/bind.go
+++ b/bind.go
@@ -103,7 +103,8 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		length int
 	}
 
-	var flatArgsCount, sliceCount int
+	var flatArgsCount int
+	var anySlices bool
 
 	meta := make([]argMeta, len(args))
 
@@ -115,7 +116,7 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 			meta[i].length = v.Len()
 			meta[i].v = v
 
-			sliceCount++
+			anySlices = true
 			flatArgsCount += meta[i].length
 
 			if meta[i].length == 0 {
@@ -129,7 +130,7 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 
 	// don't do any parsing if there aren't any slices;  note that this means
 	// some errors that we might have caught below will not be returned.
-	if sliceCount == 0 {
+	if !anySlices {
 		return query, args, nil
 	}
 

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1228,7 +1228,7 @@ func TestIn(t *testing.T) {
 			t.Error(err)
 		}
 		if len(a) != test.c {
-			t.Errorf("Expected %d args, but got %d (%+v)", len(a), test.c, a)
+			t.Errorf("Expected %d args, but got %d (%+v)", test.c, len(a), a)
 		}
 		if strings.Count(q, "?") != test.c {
 			t.Errorf("Expected %d bindVars, got %d", test.c, strings.Count(q, "?"))
@@ -1457,6 +1457,14 @@ func BenchmarkBindMap(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		bindMap(DOLLAR, q1, am)
+	}
+}
+
+func BenchmarkIn(b *testing.B) {
+	q := `SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?`
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = In(q, []interface{}{"foo", []int{0, 5, 7, 2, 9}, "bar"}...)
 	}
 }
 


### PR DESCRIPTION
Optimize indexing performance and allocations of sqlx.In, by using strings.IndexByte for finding '?' characters and precomputing the capacity for the new args slice. Also call reflectx.Deref directly to void allocating an error when an argument is not a slice.

Add a benchmark for calling 'In'.

Improvements on current go stable (1.4.2, linux/amd64):

```
benchmark       old ns/op     new ns/op     delta
BenchmarkIn     5913          1785          -69.81%

benchmark       old allocs     new allocs     delta
BenchmarkIn     32             13             -59.38%

benchmark       old bytes     new bytes     delta
BenchmarkIn     941           584           -37.94%
```

Same benchmark on tip (devel +3ae1704, linux/amd64):

```
benchmark       old ns/op     new ns/op     delta
BenchmarkIn     9461          1269          -86.59%

benchmark       old allocs     new allocs     delta
BenchmarkIn     28             13             -53.57%

benchmark       old bytes     new bytes     delta
BenchmarkIn     976           624           -36.07%
```