### PR TITLE
[Doc] Fix a typo in discussion of non-embedded structs

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@ type Employee struct {
 }
 </pre>
 
-<p>Not that sqlx historically supported this feature for non-embedded structs, this ended up being confusing because users were using this feature to define relationships and embedding the same structs twice:</p>
+<p>Note that sqlx historically supported this feature for non-embedded structs, this ended up being confusing because users were using this feature to define relationships and embedding the same structs twice:</p>
 <pre class="prettyprint linenums">
 type Child struct {
     Father Person

--- a/index.md
+++ b/index.md
@@ -409,7 +409,7 @@ type Employee struct {
 }
 ```
 
-Not that sqlx historically supported this feature for non-embedded structs, this ended up being confusing because users were using this feature to define relationships and embedding the same structs twice:
+Note that sqlx historically supported this feature for non-embedded structs, this ended up being confusing because users were using this feature to define relationships and embedding the same structs twice:
 
 ```go
 type Child struct {


### PR DESCRIPTION
Just a minor typo.