### PR TITLE
Add NamedStmt.Selectx

### DIFF
--- a/named.go
+++ b/named.go
@@ -99,6 +99,17 @@ func (n *NamedStmt) Select(dest interface{}, arg interface{}) error {
 	return scanAll(rows, dest, false)
 }
 
+// Selectx using this NamedStmt
+func (n *NamedStmt) Selectx(dest interface{}, arg interface{}) error {
+	rows, err := n.Queryx(arg)
+	if err != nil {
+		return err
+	}
+	// if something happens here, we want to make sure the rows are Closed
+	defer rows.Close()
+	return scanAll(rows, dest, false)
+}
+
 // Get using this NamedStmt
 func (n *NamedStmt) Get(dest interface{}, arg interface{}) error {
 	r := n.QueryRowx(arg)


### PR DESCRIPTION
First up, thanks for the great lib. As a kiwi it's cool to see the tests full of All Blacks too.

We're using named statements and a custom mapper, and couldn't use the handy `Select` method as the custom mapper would not get passed through. This fixes that. Let me know if this isn't a good solution.

![Rugby Tax](http://cdn.makeagif.com/media/5-12-2015/_lNPdv.gif)