### PR TITLE
Add support for NamedQueryRow

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -287,6 +287,12 @@ func (db *DB) NamedQuery(query string, arg interface{}) (*Rows, error) {
 	return NamedQuery(db, query, arg)
 }
 
+// NamedQueryRow using this DB.
+func (db *DB) NamedQueryRow(query string, arg interface{}) *Row {
+	rows, err := NamedQuery(db, query, arg)
+	return &Row{rows: rows.Rows, err: err, unsafe: db.unsafe, Mapper: db.Mapper}
+}
+
 // NamedExec using this DB.
 func (db *DB) NamedExec(query string, arg interface{}) (sql.Result, error) {
 	return NamedExec(db, query, arg)
@@ -383,6 +389,12 @@ func (tx *Tx) BindNamed(query string, arg interface{}) (string, []interface{}, e
 // NamedQuery within a transaction.
 func (tx *Tx) NamedQuery(query string, arg interface{}) (*Rows, error) {
 	return NamedQuery(tx, query, arg)
+}
+
+// NamedQueryRow within a transaction.
+func (tx *Tx) NamedQueryRow(query string, arg interface{}) *Row {
+	rows, err := NamedQuery(tx, query, arg)
+	return &Row{rows: rows.Rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
 }
 
 // NamedExec a named query within a transaction.

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -685,6 +685,32 @@ func TestNamedQuery(t *testing.T) {
 
 		check(t, rows)
 
+		row := db.NamedQueryRow(pdb(`
+			SELECT * FROM jsperson
+			WHERE
+				"FIRST"=:FIRST AND
+				last_name=:last_name AND
+				"EMAIL"=:EMAIL
+		`, db), jp)
+
+		jp2 := JSONPerson{}
+		err = row.StructScan(&jp2)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if jp2.Email != jp.Email {
+			t.Errorf("Email Mismatch %s", db.DriverName())
+		}
+
+		if jp2.FirstName != jp.FirstName {
+			t.Errorf("FirstName Mismatch %s", db.DriverName())
+		}
+
+		if jp2.LastName != jp.LastName {
+			t.Errorf("LastName Mismatch %s", db.DriverName())
+		}
+
 		db.Mapper = &old
 
 	})


### PR DESCRIPTION
We have functions:

```QueryRowx(query string, args ...interface{}) *Row```, which takes in a normal list of sql args, and returns a pointer to a single sqlx.Row

```NamedQuery(query string, arg interface{}) (*Rows, error)```, which takes in a single struct, and returns a pointer to a list of sqlx.Rows

This PR adds:
```NamedQueryRow(query string, arg interface{}) *Row```, which takes in a single struct, and returns a pointer to a single sqlx.Row