### PR TITLE
Pretty printing for types.JsonText

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -99,3 +99,8 @@ func (j *JsonText) Scan(src interface{}) error {
 func (j *JsonText) Unmarshal(v interface{}) error {
 	return json.Unmarshal([]byte(*j), v)
 }
+
+// Pretty printing for JsonText types
+func (j JsonText) String() string {
+	return string(j)
+}


### PR DESCRIPTION
Without this, JsonText types print out as a byte array, e.g.: [123 34 110 97 109 101 34 58 32 34 77 97 116 116 32...]

With this, they print out as a normal string, e.g.: {"name": "Matt Barton", "gender": "male", "picture": "", ...