### PR TITLE
reflectx: update struct field walking for Go 1.6 changes

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -326,7 +326,7 @@ func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc func(string)
 			}
 
 			// skip unexported fields
-			if len(f.PkgPath) != 0 {
+			if len(f.PkgPath) != 0 && !f.Anonymous {
 				continue
 			}
 


### PR DESCRIPTION
It's now necessary to check Anonymous as well as PkgPath to skip an
unexported field.  See http://tip.golang.org/doc/go1.6#reflect.

Fixes TestBindStruct when building with Go 1.6.