### PR TITLE
Allow multiple tag names

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jmoiron/sqlx/reflectx"
+	"github.com/snikch/sqlx/reflectx"
 )
 
 // Bindvar types supported by Rebind, BindMap and BindStruct.

--- a/named.go
+++ b/named.go
@@ -243,7 +243,7 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 			inName = true
 			name = []byte{}
 			// if we're in a name, and this is an allowed character, continue
-		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_') && i != last {
+		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_' || b == '.') && i != last {
 			// append the byte to the name if we are in a name and not on the last byte
 			name = append(name, b)
 			// if we're in a name and it's not an allowed character, the name is done

--- a/named.go
+++ b/named.go
@@ -99,6 +99,17 @@ func (n *NamedStmt) Select(dest interface{}, arg interface{}) error {
 	return scanAll(rows, dest, false)
 }
 
+// Selectx using this NamedStmt
+func (n *NamedStmt) Selectx(dest interface{}, arg interface{}) error {
+	rows, err := n.Queryx(arg)
+	if err != nil {
+		return err
+	}
+	// if something happens here, we want to make sure the rows are Closed
+	defer rows.Close()
+	return scanAll(rows, dest, false)
+}
+
 // Get using this NamedStmt
 func (n *NamedStmt) Get(dest interface{}, arg interface{}) error {
 	r := n.QueryRowx(arg)

--- a/named.go
+++ b/named.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"unicode"
 
-	"github.com/jmoiron/sqlx/reflectx"
+	"github.com/snikch/sqlx/reflectx"
 )
 
 // NamedStmt is a prepared statement that executes named queries.  Prepare it

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -161,6 +161,28 @@ func TestFlatTags(t *testing.T) {
 	}
 }
 
+func TestMultipleTags(t *testing.T) {
+	m := NewMapper("db", "json")
+
+	type Foo struct {
+		Bar string `json:"-" db:"bar"`
+		Baz string `json:"baz"`
+	}
+	// Post columns: (author title)
+
+	foo := Foo{Bar: "a", Baz: "b"}
+	fv := reflect.ValueOf(foo)
+
+	v := m.FieldByName(fv, "bar")
+	if v.Interface().(string) != foo.Bar {
+		t.Errorf("Expecting %s, got %s", foo.Bar, v.Interface().(string))
+	}
+	v = m.FieldByName(fv, "baz")
+	if v.Interface().(string) != foo.Baz {
+		t.Errorf("Expecting %s, got %s", foo.Baz, v.Interface().(string))
+	}
+}
+
 func TestNestedStruct(t *testing.T) {
 	m := NewMapper("db")
 

--- a/sqlx.go
+++ b/sqlx.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/jmoiron/sqlx/reflectx"
+	"github.com/snikch/sqlx/reflectx"
 )
 
 // Although the NameMapper is convenient, in practice it should not

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx/reflectx"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/snikch/sqlx/reflectx"
 )
 
 /* compile time checks that Db, Tx, Stmt (qStmt) implement expected interfaces */


### PR DESCRIPTION
**Note** This PR isn't actually ready for merge since it updates the main package to use my fork

Hey there,

One of the use cases that I have for field names is the idea of generally using the `json` tag, but needing to override it on occasion for data that should be retrieved from the db, but not marshalled to json. By adding multiple tag support to `reflectx` I can save myself managing two tags.

For example, most of our data is encrypted with a per row nonce. We don't want to expose that nonce, but also don't want to expose the nonce via json. By using `json` tags for most fields, but using the `db` tag when it's available, I can easily provide this functionality.

``` go
type MyStruct struct {
  Name string `json:"name"`
  Nonce string `json:"-" db:"nonce"`
}

// My mapper
myDBClient.Mapper = reflectx.Mapper("db", "json")
```

Does this seem like something you'd like to support? If so we can talk about the implementation - my current one doesn't support multiple tags when using a mapper func - but a setter could be used to adjust or append to the tag names. It just seemed easiest to add a variadic parameter to the `reflectx.Mapper` function so that the api was backwards compatible.
