### PR TITLE
call NewMapperTagFunc's tagFunc before parsing name/options

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -288,6 +288,9 @@ func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc func(string)
 			var tag, name string
 			if tagName != "" && strings.Contains(string(f.Tag), tagName+":") {
 				tag = f.Tag.Get(tagName)
+				if tagMapFunc != nil {
+					tag = tagMapFunc(tag)
+				}
 				name = tag
 			} else {
 				if mapFunc != nil {
@@ -306,10 +309,6 @@ func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc func(string)
 						fi.Options[kv[0]] = ""
 					}
 				}
-			}
-
-			if tagMapFunc != nil {
-				tag = tagMapFunc(tag)
 			}
 
 			fi.Name = name

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -457,6 +457,25 @@ func TestTagNameMapping(t *testing.T) {
 			t.Errorf("Expecting to find key %s in mapping but did not.", key)
 		}
 	}
+
+	m = NewMapperTagFunc("protobuf", strings.ToUpper, func(value string) string {
+		if strings.Contains(value, ",") {
+			for _, piece := range strings.Split(value, ",") {
+				if strings.HasPrefix(piece, "name=") {
+					return strings.TrimPrefix(piece, "name=")
+				}
+			}
+		}
+		return value
+	})
+	strategy = Strategy{"1", "Alpah"}
+	mapping = m.TypeMap(reflect.TypeOf(strategy))
+
+	for _, key := range []string{"strategy_id", "STRATEGYNAME"} {
+		if fi := mapping.GetByPath(key); fi == nil {
+			t.Errorf("Expecting to find key %s in mapping but did not.", key)
+		}
+	}
 }
 
 func TestMapping(t *testing.T) {


### PR DESCRIPTION
May be I don't understand how `NewMapperTagFunc` is supposed to work, but it seems like the `tagMapFunc` needs to be called before [these lines](https://github.com/jlburkhead/sqlx/blob/c45bd30dde7197190548576fe3c5005d010dc75a/reflectx/reflect.go#L301) so that name and options are set for the field. Even if my understanding of how the `tagMapFunc` works is off, the test needs to be fixed since any func (or `nil`) works as the third arg to `NewMapperTagFunc` in `TestTagNameMapping`.