### PR TITLE
Enable nested structs to work inside NamedQuery, NamedExec, etc.

### DIFF
--- a/named.go
+++ b/named.go
@@ -250,7 +250,7 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 			inName = true
 			name = []byte{}
 			// if we're in a name, and this is an allowed character, continue
-		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_') && i != last {
+		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_' || b == '.') && i != last {
 			// append the byte to the name if we are in a name and not on the last byte
 			name = append(name, b)
 			// if we're in a name and it's not an allowed character, the name is done


### PR DESCRIPTION
This extends the work done in #131 so that fields from nested structs can be referenced in named queries (e.g. :place.name).  The only problem was that "." wasn't considered part of the field name.