### PR TITLE
Make sqlx.scanAll() publicly available as sqlx.ScanAll()

### DIFF
--- a/named.go
+++ b/named.go
@@ -96,7 +96,7 @@ func (n *NamedStmt) Select(dest interface{}, arg interface{}) error {
 	}
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
-	return scanAll(rows, dest, false)
+	return ScanAll(rows, dest, false)
 }
 
 // Get using this NamedStmt

--- a/sqlx.go
+++ b/sqlx.go
@@ -633,7 +633,7 @@ func Select(q Queryer, dest interface{}, query string, args ...interface{}) erro
 	}
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
-	return scanAll(rows, dest, false)
+	return ScanAll(rows, dest, false)
 }
 
 // Get does a QueryRow using the provided Queryer, and scans the resulting row
@@ -826,7 +826,7 @@ func structOnlyError(t reflect.Type) error {
 	return fmt.Errorf("expected a struct, but struct %s has no exported fields", t.Name())
 }
 
-// scanAll scans all rows into a destination, which must be a slice of any
+// ScanAll scans all rows into a destination, which must be a slice of any
 // type.  If the destination slice type is a Struct, then StructScan will be
 // used on each row.  If the destination is some other kind of base type, then
 // each row must only have one column which can scan into that type.  This
@@ -834,14 +834,14 @@ func structOnlyError(t reflect.Type) error {
 //
 //    rows, _ := db.Query("select id from people;")
 //    var ids []int
-//    scanAll(rows, &ids, false)
+//    ScanAll(rows, &ids, false)
 //
 // and ids will be a list of the id results.  I realize that this is a desirable
 // interface to expose to users, but for now it will only be exposed via changes
 // to `Get` and `Select`.  The reason that this has been implemented like this is
 // this is the only way to not duplicate reflect work in the new API while
 // maintaining backwards compatibility.
-func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
+func ScanAll(rows rowsi, dest interface{}, structOnly bool) error {
 	var v, vp reflect.Value
 
 	value := reflect.ValueOf(dest)
@@ -941,7 +941,7 @@ func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
 // allocate structs for the entire result, use Queryx and see sqlx.Rows.StructScan.
 // If rows is sqlx.Rows, it will use its mapper, otherwise it will use the default.
 func StructScan(rows rowsi, dest interface{}) error {
-	return scanAll(rows, dest, true)
+	return ScanAll(rows, dest, true)
 
 }
 

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1132,7 +1132,7 @@ func TestUsage(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		err = scanAll(rows, &sdest, false)
+		err = ScanAll(rows, &sdest, false)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
This is useful in some cases, e.g. when parsing multiple rows into an array of structs using
sqlx.NamedQuery().

```go
func GetWithNamedQuery(db sqlx.DB, target interface{}, query string, arg interface{}) (err error) {
    rows, err = db.NamedQuery(query, arg)
    if err != nil {
        return
    }

    // If something happens here, we want to make sure the rows are closed
    defer rows.Close()

    // This depends on sqlx.ScanAll() being an exported function.
    err = sqlx.ScanAll(rows, obj, false)
    return
}
```

The caller could then build (SQL injection secure) queries using something like this:

```go
// The id is mandatory
query := []string{`SELECT * FROM table WHERE id=:id`}

// Only filter for type if type was given
if where.Type != "" {
    query = append(query, `AND type=:type`)
}

// Only filter for state if state was given
if where.State != "" {
    query = append(query, `AND state=:state`)
}

// Order results
query = append(query, `ORDER BY created_at ASC`)
err = sql.NamedQuery(db, &contributions, strings.Join(query, " "), where)
```

I'm not sure whether this is the best option to build more dynamic queries, but I couldn't find a better option yet. Hints apprechiated.