### PR TITLE
Add type BitBool Scanner/Valuer for MySQL type BIT

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -107,3 +107,28 @@ func (j *JSONText) Unmarshal(v interface{}) error {
 func (j JSONText) String() string {
 	return string(j)
 }
+
+// BitBool is an implementation of a bool for the MySQL type BIT(1).
+// This type allows you to avoid wasting an entire byte for MySQL's boolean type TINYINT.
+type BitBool bool
+
+// Value implements the driver.Valuer interface,
+// and turns the BitBool into a bitfield (BIT(1)) for MySQL storage.
+func (b BitBool) Value() (driver.Value, error) {
+	if b {
+		return []byte{1}, nil
+	} else {
+		return []byte{0}, nil
+	}
+}
+
+// Scan implements the sql.Scanner interface,
+// and turns the bitfield incoming from MySQL into a BitBool
+func (b *BitBool) Scan(src interface{}) error {
+	v, ok := src.([]byte)
+	if !ok {
+		return errors.New("bad []byte type assertion")
+	}
+	*b = v[0] == 1
+	return nil
+}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -40,3 +40,35 @@ func TestJSONText(t *testing.T) {
 		t.Errorf("Was expecting invalid json to fail!")
 	}
 }
+
+func TestBitBool(t *testing.T) {
+	// Test true value
+	var b BitBool = true
+
+	v, err := b.Value()
+	if err != nil {
+		t.Errorf("Cannot return error")
+	}
+	err = (&b).Scan(v)
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	if !b {
+		t.Errorf("Was expecting the bool we sent in (true), got %b", b)
+	}
+
+	// Test false value
+	b = false
+
+	v, err = b.Value()
+	if err != nil {
+		t.Errorf("Cannot return error")
+	}
+	err = (&b).Scan(v)
+	if err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	if b {
+		t.Errorf("Was expecting the bool we sent in (false), got %b", b)
+	}
+}


### PR DESCRIPTION
Allows Go to read and write MySQL BIT(1) type as a bool. This allows you to use 1 bit for a MySQL boolean instead of 1 byte for the standard TINYINT. BitBool type itself is simply an alias for bool, so it can be used easily in Go code.