### PR TITLE
reflectx: don't mapping recursive field

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -330,10 +330,19 @@ func getMapping(t reflect.Type, tagName string, mapFunc, tagMapFunc mapf) *Struc
 	queue := []typeQueue{}
 	queue = append(queue, typeQueue{Deref(t), root, ""})
 
+QueueLoop:
 	for len(queue) != 0 {
 		// pop the first item off of the queue
 		tq := queue[0]
 		queue = queue[1:]
+
+		// ignore recursive field
+		for p := tq.fi.Parent; p != nil; p = p.Parent {
+			if tq.fi.Field.Type == p.Field.Type {
+				continue QueueLoop
+			}
+		}
+
 		nChildren := 0
 		if tq.t.Kind() == reflect.Struct {
 			nChildren = tq.t.NumField()

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -247,6 +247,15 @@ func TestInlineStruct(t *testing.T) {
 	}
 }
 
+func TestRecursiveStruct(t *testing.T) {
+	type Person struct {
+		Parent *Person
+	}
+	m := NewMapperFunc("db", strings.ToLower)
+	var p *Person
+	m.TypeMap(reflect.TypeOf(p))
+}
+
 func TestFieldsEmbedded(t *testing.T) {
 	m := NewMapper("db")
 


### PR DESCRIPTION
the recursive struct will cause  `getMapping` loop forever.

e.g: 
```
type Person struct {
	Parent *Person
}
```
