### PR TITLE
Restore JSONText MarshalJSON behaviour

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -60,11 +60,11 @@ type JSONText json.RawMessage
 var emptyJSON = JSONText("{}")
 
 // MarshalJSON returns the *j as the JSON encoding of j.
-func (j *JSONText) MarshalJSON() ([]byte, error) {
-	if len(*j) == 0 {
-		*j = emptyJSON
+func (j JSONText) MarshalJSON() ([]byte, error) {
+	if len(j) == 0 {
+		j = emptyJSON
 	}
-	return *j, nil
+	return j, nil
 }
 
 // UnmarshalJSON sets *j to a copy of data


### PR DESCRIPTION
closes #266

When using `JSONText` in a struct, the field is not a pointer, and therefore the func is never called, leading to unexpected results.
This change works with `*JSONText`, as well as `JSONText`.

Thanks.