### PR TITLE
scanAny: add nil check

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -717,6 +717,10 @@ func (r *Row) scanAny(dest interface{}, structOnly bool) error {
 	if r.err != nil {
 		return r.err
 	}
+	if r.rows == nil {
+		r.err = sql.ErrNoRows
+		return r.err
+	}
 	defer r.rows.Close()
 
 	v := reflect.ValueOf(dest)


### PR DESCRIPTION
The package-level function Get calls the interface method QueryRowx
which is expected to return *Row. Implementations of that interface
in another package can't possibly set the unexported rows field, so
it must be checked for nil before accessing it. 