### PR TITLE
Optimize Rebind performance and allocations

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -43,27 +43,28 @@ func Rebind(bindType int, query string) string {
 		return query
 	}
 
-	qb := []byte(query)
 	// Add space enough for 10 params before we have to allocate
-	rqb := make([]byte, 0, len(qb)+10)
-	j := 1
-	for _, b := range qb {
-		if b == '?' {
-			switch bindType {
-			case DOLLAR:
-				rqb = append(rqb, '$')
-			case NAMED:
-				rqb = append(rqb, ':', 'a', 'r', 'g')
-			}
-			for _, b := range strconv.Itoa(j) {
-				rqb = append(rqb, byte(b))
-			}
-			j++
-		} else {
-			rqb = append(rqb, b)
+	rqb := make([]byte, 0, len(query)+10)
+
+	var i, j int
+
+	for i = strings.Index(query, "?"); i != -1; i = strings.Index(query, "?") {
+		rqb = append(rqb, query[:i]...)
+
+		switch bindType {
+		case DOLLAR:
+			rqb = append(rqb, '$')
+		case NAMED:
+			rqb = append(rqb, ':', 'a', 'r', 'g')
 		}
+
+		j++
+		rqb = strconv.AppendInt(rqb, int64(j), 10)
+
+		query = query[i+1:]
 	}
-	return string(rqb)
+
+	return string(append(rqb, query...))
 }
 
 // Experimental implementation of Rebind which uses a bytes.Buffer.  The code is


### PR DESCRIPTION
Avoids many append calls and a string->[]byte conversion.

Benchstat:

```
name            old time/op    new time/op    delta
Rebind-8          1.01µs ± 1%    0.59µs ± 1%  -41.75%  (p=0.000 n=10+10)
RebindBuffer-8    2.55µs ± 0%    2.55µs ± 1%     ~     (p=0.589 n=9+10)

name            old alloc/op   new alloc/op   delta
Rebind-8            493B ± 0%      336B ± 0%  -31.85%  (p=0.000 n=10+10)
RebindBuffer-8      829B ± 0%      829B ± 0%     ~     (all equal)

name            old allocs/op  new allocs/op  delta
Rebind-8            19.0 ± 0%       4.0 ± 0%  -78.95%  (p=0.000 n=10+10)
RebindBuffer-8      21.0 ± 0%      21.0 ± 0%     ~     (all equal)
```