### PR TITLE
Optimize In by specializing for concrete slice types

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -135,9 +135,9 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 	}
 
 	newArgs := make([]interface{}, 0, flatArgsCount)
+	buf := bytes.NewBuffer(make([]byte, 0, len(query)+len(", ?")*flatArgsCount))
 
 	var arg, offset int
-	var buf bytes.Buffer
 
 	for i := strings.IndexByte(query[offset:], '?'); i != -1; i = strings.IndexByte(query[offset:], '?') {
 		if arg >= len(meta) {
@@ -163,12 +163,11 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		// write everything up to and including our ? character
 		buf.WriteString(query[:offset+i+1])
 
-		newArgs = append(newArgs, argMeta.v.Index(0).Interface())
-
 		for si := 1; si < argMeta.length; si++ {
 			buf.WriteString(", ?")
-			newArgs = append(newArgs, argMeta.v.Index(si).Interface())
 		}
+
+		newArgs = appendReflectSlice(newArgs, argMeta.v, argMeta.length)
 
 		// slice the query and reset the offset. this avoids some bookkeeping for
 		// the write after the loop
@@ -183,4 +182,25 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 	}
 
 	return buf.String(), newArgs, nil
+}
+
+func appendReflectSlice(args []interface{}, v reflect.Value, vlen int) []interface{} {
+	switch val := v.Interface().(type) {
+	case []interface{}:
+		args = append(args, val...)
+	case []int:
+		for i := range val {
+			args = append(args, val[i])
+		}
+	case []string:
+		for i := range val {
+			args = append(args, val[i])
+		}
+	default:
+		for si := 0; si < vlen; si++ {
+			args = append(args, v.Index(si).Interface())
+		}
+	}
+
+	return args
 }

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1726,6 +1726,36 @@ func BenchmarkIn(b *testing.B) {
 	}
 }
 
+func BenchmarkIn1k(b *testing.B) {
+	q := `SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?`
+
+	var vals [1000]interface{}
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = In(q, []interface{}{"foo", vals[:], "bar"}...)
+	}
+}
+
+func BenchmarkIn1kInt(b *testing.B) {
+	q := `SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?`
+
+	var vals [1000]int
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = In(q, []interface{}{"foo", vals[:], "bar"}...)
+	}
+}
+
+func BenchmarkIn1kString(b *testing.B) {
+	q := `SELECT * FROM foo WHERE x = ? AND v in (?) AND y = ?`
+
+	var vals [1000]string
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = In(q, []interface{}{"foo", vals[:], "bar"}...)
+	}
+}
+
 func BenchmarkRebind(b *testing.B) {
 	b.StopTimer()
 	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`


### PR DESCRIPTION
Most uses of In (or similar functions) use []int, []interface{} or []string in my experience.

Specialize the append logic for these 3 types. For []interface{} some allocations are avoided and. For []int and []string the code still needs most allocations, but I already have another idea to remove most allocations, which could be implemented in another PR.

Also adds 3 new benchmarks with big slices of these types.

Benchstat:

```
name          old time/op    new time/op    delta
In-8             733ns ± 0%     700ns ± 1%   -4.57%  (p=0.000 n=9+10)
In1k-8          36.1µs ± 0%    17.4µs ± 1%  -51.69%  (p=0.000 n=10+10)
In1kInt-8       58.5µs ± 0%    40.4µs ± 0%  -30.92%  (p=0.000 n=10+9)
In1kString-8    73.4µs ± 1%    56.5µs ± 1%  -22.92%  (p=0.000 n=10+10)

name          old alloc/op   new alloc/op   delta
In-8              552B ± 0%      632B ± 0%  +14.49%  (p=0.000 n=10+10)
In1k-8          29.1kB ± 0%    22.8kB ± 0%  -21.52%  (p=0.000 n=10+10)
In1kInt-8       37.1kB ± 0%    30.8kB ± 0%  -16.88%  (p=0.000 n=10+10)
In1kString-8    45.1kB ± 0%    38.8kB ± 0%  -13.88%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
In-8              11.0 ± 0%      12.0 ± 0%   +9.09%  (p=0.000 n=10+10)
In1k-8            11.0 ± 0%       6.0 ± 0%  -45.45%  (p=0.000 n=10+10)
In1kInt-8        1.01k ± 0%     1.01k ± 0%   -0.49%  (p=0.000 n=10+10)
In1kString-8     1.01k ± 0%     1.01k ± 0%   -0.49%  (p=0.000 n=10+10)
```