### PR TITLE
Add QueryxContext, QueryRowxContext and GetContext to sqlx.Tx

### DIFF
--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -256,8 +256,8 @@ func (tx *Tx) QueryRowxContext(ctx context.Context, query string, args ...interf
 	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
 }
 
-func (tx *Tx) GetContext(ctx context.Context, dest interface{}, args ...interface{}) error {
-	return GetContext(ctx, tx, dest, "", args...)
+func (tx *Tx) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	return GetContext(ctx, tx, dest, query, args...)
 }
 
 // SelectContext using the prepared statement.

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -243,6 +243,23 @@ func (tx *Tx) MustExecContext(ctx context.Context, query string, args ...interfa
 	return MustExecContext(ctx, tx, query, args...)
 }
 
+func (tx *Tx) QueryxContext(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
+	r, err := tx.Tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &Rows{Rows: r, unsafe: tx.unsafe, Mapper: tx.Mapper}, err
+}
+
+func (tx *Tx) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *Row {
+	rows, err := tx.Tx.QueryContext(ctx, query, args...)
+	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
+}
+
+func (tx *Tx) GetContext(ctx context.Context, dest interface{}, args ...interface{}) error {
+	return GetContext(ctx, tx, dest, "", args...)
+}
+
 // SelectContext using the prepared statement.
 // Any placeholder parameters are replaced with supplied args.
 func (s *Stmt) SelectContext(ctx context.Context, dest interface{}, args ...interface{}) error {


### PR DESCRIPTION
This adds QueryxContext, QueryRowxContext and GetContext functions to sqlx.Tx, without those, it is not possible to use cancellation or context-based tracing and logging.