### PR TITLE
Return string type for JSONText.Value()

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -82,9 +82,10 @@ func (j JSONText) Value() (driver.Value, error) {
 	var m json.RawMessage
 	var err = j.Unmarshal(&m)
 	if err != nil {
-		return []byte{}, err
+		return "", err
 	}
-	return []byte(j), nil
+	// Return as a string, so that it can be encoded via text format
+	return string(j), nil
 }
 
 // Scan stores the src in *j.  No validation is done.


### PR DESCRIPTION
In order to support `binary_parameters` flag in lib/pq, we need to explicitly return string type to signal lib/pq to send the field via text format (pointed out by cbandy at https://github.com/lib/pq/issues/528).

We've been testing this fork in production for a few days with pgbouncer transaction pooling mode, and so far things are working as expected.