### PR TITLE
Tests With docker-compose

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,18 @@
+# Start from a Debian image with the latest version of Go installed
+# and a workspace (GOPATH) configured at /go.
+FROM golang
+
+# Set environment variables
+ENV PATH /go/bin:$PATH
+
+# Cd into the library code directory
+WORKDIR /go/src/github.com/jmoiron/sqlx
+
+# Copy the local package files to the container's workspace.
+ADD . /go/src/github.com/jmoiron/sqlx
+
+# Install dependencies
+RUN go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs -n1 go get -d
+
+# Run integration tests as default command
+CMD go list ./... | xargs -n1 go test -timeout=30s

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+ci:
+	bash -c '(docker-compose -f docker-compose.test.yml -p sqlx_ci up --build -d) && (docker logs -f sqlx_sut &) && (docker wait sqlx_sut)'

--- a/README.md
+++ b/README.md
@@ -181,3 +181,10 @@ func main() {
 }
 ```
 
+## development 
+
+You can use `docker-compose` to run the tests during development. It will run the test suite in a platform agnostic way:
+
+```sh
+make ci
+```

--- a/default.test.env
+++ b/default.test.env
@@ -1,0 +1,3 @@
+SQLX_SQLITE_DSN=skip
+SQLX_POSTGRES_DSN="sslmode=disable host=postgres port=5432 user=root password='root_password' dbname=sqlx_test"
+SQLX_MYSQL_DSN="root:root_password@tcp(mysql:3306)/sqlx_test"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,32 @@
+version: "2"
+
+services:
+  mysql:
+    container_name: sqlx_sut_mysql
+    image: "mysql"
+    environment:
+      MYSQL_ROOT_PASSWORD: "root_password"
+      MYSQL_DATABASE: "sqlx_test"
+
+  postgres:
+    container_name: sqlx_sut_postgres
+    image: "postgres"
+    environment:
+      POSTGRES_USER: "root"
+      POSTGRES_PASSWORD: "root_password"
+      POSTGRES_DB: "sqlx_test"
+
+  sut:
+    container_name: sqlx_sut
+    image: sqlx_sut:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile.test
+    env_file:
+      - ./default.test.env
+    depends_on:
+      - mysql
+      - postgres
+    links:
+      - mysql
+      - postgres


### PR DESCRIPTION
I have added a platform agnostic way to run tests with docker-compose:

```sh
(docker-compose -f docker-compose.test.yml -p sqlx_ci up --build -d) && (docker logs -f sqlx_sut &) && (docker wait sqlx_sut)
```

This should make development easier as you can run tests from any machine with docker engine, you don't have to have a proper development setup locally.

Since the command is long, I have added a Makefile with alias to run tests:

```
make ci
```