### PR TITLE
Valuer objects should be evaluated before In expansion

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -110,6 +110,9 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 	meta := make([]argMeta, len(args))
 
 	for i, arg := range args {
+		if a, ok := arg.(driver.Valuer); ok {
+			arg, _ = a.Value()
+		}
 		v := reflect.ValueOf(arg)
 		t := reflectx.Deref(v.Type())
 


### PR DESCRIPTION
Value() method of Valuer objects may change slices into non-slice objects or vice-versa.
Therefore we must do the evaluation before the expansion.