### PR TITLE
[]byte should not be expanded by In

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -113,7 +113,7 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		v := reflect.ValueOf(arg)
 		t := reflectx.Deref(v.Type())
 
-		if t.Kind() == reflect.Slice {
+		if t.Kind() == reflect.Slice && t != reflect.TypeOf([]byte{}) {
 			meta[i].length = v.Len()
 			meta[i].v = v
 

--- a/bind.go
+++ b/bind.go
@@ -113,6 +113,7 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		v := reflect.ValueOf(arg)
 		t := reflectx.Deref(v.Type())
 
+		// []byte is a driver.Value type so it should not be expanded
 		if t.Kind() == reflect.Slice && t != reflect.TypeOf([]byte{}) {
 			meta[i].length = v.Len()
 			meta[i].v = v

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1490,6 +1490,9 @@ func TestIn(t *testing.T) {
 		{"SELECT * FROM foo WHERE x in (?)",
 			[]interface{}{[]int{1, 2, 3, 4, 5, 6, 7, 8}},
 			8},
+		{"SELECT * FROM foo WHERE x = ? AND y in (?)",
+			[]interface{}{[]byte("foo"), []int{0, 5, 3}},
+			4},
 	}
 	for _, test := range tests {
 		q, a, err := In(test.q, test.args...)


### PR DESCRIPTION
[]byte is one of the driver.Value types, and should therefore not be expanded by `In`.