### PR TITLE
compare NameMapper and origMapper properly

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -41,7 +41,7 @@ func mapper() *reflectx.Mapper {
 
 	if mpr == nil {
 		mpr = reflectx.NewMapperFunc("db", NameMapper)
-	} else if origMapper != reflect.ValueOf(NameMapper) {
+	} else if origMapper.Interface() != reflect.ValueOf(NameMapper).Interface() {
 		// if NameMapper has changed, create a new mapper
 		mpr = reflectx.NewMapperFunc("db", NameMapper)
 		origMapper = reflect.ValueOf(NameMapper)


### PR DESCRIPTION
https://golang.org/pkg/reflect/#Value:
    Using == on two Values does not compare the underlying values they represent,
    but rather the contents of the Value structs.
    To compare two Values, compare the results of the Interface method.
