### PR TITLE
Add QueryRow methods for named queries

### DIFF
--- a/named.go
+++ b/named.go
@@ -322,7 +322,7 @@ func bindNamedMapper(bindType int, query string, arg interface{}, m *reflectx.Ma
 }
 
 // NamedQuery binds a named query and then runs Query on the result using the
-// provided Ext (sqlx.Tx, sqlx.Db).  It works with both structs and with
+// provided Ext (sqlx.Tx, sqlx.Db). It works with both structs and with
 // map[string]interface{} types.
 func NamedQuery(e Ext, query string, arg interface{}) (*Rows, error) {
 	q, args, err := bindNamedMapper(BindType(e.DriverName()), query, arg, mapperFor(e))
@@ -330,6 +330,17 @@ func NamedQuery(e Ext, query string, arg interface{}) (*Rows, error) {
 		return nil, err
 	}
 	return e.Queryx(q, args...)
+}
+
+// NamedQueryRow binds a named query and then runs QueryRow on the result using
+// the provided Ext (sqlx.Tx, sqlx.Db). It works with both structs and with
+// map[string]interface{} types.
+func NamedQueryRow(e Ext, query string, arg interface{}) (*Row, error) {
+	q, args, err := bindNamedMapper(BindType(e.DriverName()), query, arg, mapperFor(e))
+	if err != nil {
+		return nil, err
+	}
+	return e.QueryRowx(q, args...), nil
 }
 
 // NamedExec uses BindStruct to get a query executable by the driver and

--- a/named_context.go
+++ b/named_context.go
@@ -120,6 +120,17 @@ func NamedQueryContext(ctx context.Context, e ExtContext, query string, arg inte
 	return e.QueryxContext(ctx, q, args...)
 }
 
+// NamedQueryRowContext binds a named query and then runs QueryRow on the result
+// using the provided Ext (sqlx.Tx, sqlx.Db).  It works with both structs and with
+// map[string]interface{} types.
+func NamedQueryRowContext(ctx context.Context, e ExtContext, query string, arg interface{}) (*Row, error) {
+	q, args, err := bindNamedMapper(BindType(e.DriverName()), query, arg, mapperFor(e))
+	if err != nil {
+		return nil, err
+	}
+	return e.QueryRowxContext(ctx, q, args...), nil
+}
+
 // NamedExecContext uses BindStruct to get a query executable by the driver and
 // then runs Exec on the result.  Returns an error from the binding
 // or the query excution itself.

--- a/sqlx.go
+++ b/sqlx.go
@@ -301,6 +301,12 @@ func (db *DB) NamedQuery(query string, arg interface{}) (*Rows, error) {
 	return NamedQuery(db, query, arg)
 }
 
+// NamedQueryRow using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+func (db *DB) NamedQueryRow(query string, arg interface{}) (*Row, error) {
+	return NamedQueryRow(db, query, arg)
+}
+
 // NamedExec using this DB.
 // Any named placeholder parameters are replaced with fields from arg.
 func (db *DB) NamedExec(query string, arg interface{}) (sql.Result, error) {
@@ -405,6 +411,12 @@ func (tx *Tx) BindNamed(query string, arg interface{}) (string, []interface{}, e
 // Any named placeholder parameters are replaced with fields from arg.
 func (tx *Tx) NamedQuery(query string, arg interface{}) (*Rows, error) {
 	return NamedQuery(tx, query, arg)
+}
+
+// NamedQueryRow within a transaction.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryRow(query string, arg interface{}) (*Row, error) {
+	return NamedQueryRow(tx, query, arg)
 }
 
 // NamedExec a named query within a transaction.

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -128,6 +128,12 @@ func (db *DB) NamedQueryContext(ctx context.Context, query string, arg interface
 	return NamedQueryContext(ctx, db, query, arg)
 }
 
+// NamedQueryRowContext using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+func (db *DB) NamedQueryRowContext(ctx context.Context, query string, arg interface{}) (*Row, error) {
+	return NamedQueryRowContext(ctx, db, query, arg)
+}
+
 // NamedExecContext using this DB.
 // Any named placeholder parameters are replaced with fields from arg.
 func (db *DB) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
@@ -271,6 +277,18 @@ func (tx *Tx) GetContext(ctx context.Context, dest interface{}, query string, ar
 func (tx *Tx) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *Row {
 	rows, err := tx.Tx.QueryContext(ctx, query, args...)
 	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
+}
+
+// NamedQueryContext using this Tx.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*Rows, error) {
+	return NamedQueryContext(ctx, tx, query, arg)
+}
+
+// NamedQueryRowContext using this Tx.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryRowContext(ctx context.Context, query string, arg interface{}) (*Row, error) {
+	return NamedQueryRowContext(ctx, tx, query, arg)
 }
 
 // NamedExecContext using this Tx.

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -656,6 +656,20 @@ func TestNamedQuery(t *testing.T) {
 			}
 		}
 
+		var f string
+		row, err := db.NamedQueryRow("SELECT first_name FROM person WHERE first_name=:first_name", p)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = row.Scan(&f)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if f != p.FirstName.String {
+			t.Error("Expected first name of `" + p.FirstName.String + "`, got " + f)
+		}
+
 		// these are tests for #73;  they verify that named queries work if you've
 		// changed the db mapper.  This code checks both NamedQuery "ad-hoc" style
 		// queries and NamedStmt queries, which use different code paths internally.


### PR DESCRIPTION
This PR adds to the library API:

- `NamedQueryRow`
- `NamedQueryRowContext`
- `(db *DB) NamedQueryRow`
- `(db *DB) NamedQueryRowContext`
- `(tx *Tx) NamedQueryRow`
- `(tx *Tx) NamedQueryRowContext`

Closes #354 