### PR TITLE
sqlx.Connect: Close db connection if db.Ping() fails

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -627,10 +627,14 @@ func (r *Rows) StructScan(dest interface{}) error {
 func Connect(driverName, dataSourceName string) (*DB, error) {
 	db, err := Open(driverName, dataSourceName)
 	if err != nil {
-		return db, err
+		return nil, err
 	}
 	err = db.Ping()
-	return db, err
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 // MustConnect connects to a database and panics on error.

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1296,9 +1296,12 @@ type Product struct {
 // tests that sqlx will not panic when the wrong driver is passed because
 // of an automatic nil dereference in sqlx.Open(), which was fixed.
 func TestDoNotPanicOnConnect(t *testing.T) {
-	_, err := Connect("bogus", "hehe")
+	db, err := Connect("bogus", "hehe")
 	if err == nil {
 		t.Errorf("Should return error when using bogus driverName")
+	}
+	if db != nil {
+		t.Errorf("Should not return the db on a connect failure")
 	}
 }
 


### PR DESCRIPTION
If the db open succeeds but the Ping() fails, close the
connection and return nil along with the error to prevent
resource leakage.

Fixes #366