### PR TITLE
Added ColumnTypes support

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -228,6 +228,14 @@ func (r *Row) Columns() ([]string, error) {
 	return r.rows.Columns()
 }
 
+// ColumnTypes returns the underlying sql.Rows.ColumnTypes(), or the deferred error
+func (r *Row) ColumnTypes() ([]*sql.ColumnType, error) {
+	if r.err != nil {
+		return []*sql.ColumnType{}, r.err
+	}
+	return r.rows.ColumnTypes()
+}
+
 // Err returns the error encountered while scanning.
 func (r *Row) Err() error {
 	return r.err


### PR DESCRIPTION
In addition to getting columns with `Columns` (already implemented), sql package also supports `ColumnTypes` which is handy (and I really need to use 😄 )