### PR TITLE
added support for the cloudsqlpostgres driver

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -21,7 +21,7 @@ const (
 // BindType returns the bindtype for a given database given a drivername.
 func BindType(driverName string) int {
 	switch driverName {
-	case "postgres", "pgx", "pq-timeouts":
+	case "postgres", "pgx", "pq-timeouts", "cloudsqlpostgres":
 		return DOLLAR
 	case "mysql":
 		return QUESTION


### PR DESCRIPTION
Google cloud has a driver for connecting to its postgres service using a secure proxy. Adding BindType support for this driver. This would address #390.

https://github.com/GoogleCloudPlatform/cloudsql-proxy/blob/master/proxy/dialers/postgres/hook_test.go