### PR TITLE
Simplify get Value

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -601,7 +601,7 @@ func (r *Rows) StructScan(dest interface{}) error {
 		return errors.New("must pass a pointer, not a value, to StructScan destination")
 	}
 
-	v = reflect.Indirect(v)
+	v = v.Elem()
 
 	if !r.started {
 		columns, err := r.Columns()


### PR DESCRIPTION
As has checked v.Kind above, no need to use indirect to get the value