### PR TITLE
Create function 'SelectResolveAsterisk'

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -439,3 +439,17 @@ QueueLoop:
 
 	return flds
 }
+
+// UnderlyingType returns the underlying type for any combination of array,
+// slice, map and pointer indirections.
+func UnderlyingType(i interface{}) reflect.Type {
+	t := reflect.TypeOf(i)
+	for {
+		switch t.Kind() {
+		case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice:
+			t = t.Elem()
+		default:
+			return t
+		}
+	}
+}

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -972,3 +972,53 @@ func BenchmarkTraversalsByNameFunc(b *testing.B) {
 		}
 	}
 }
+
+func TestUnderlyingType(t *testing.T) {
+	type A struct {
+		A1 int
+	}
+
+	var a A
+	var i int
+
+	testCases := []struct {
+		TestName     string
+		Given        interface{}
+		ExpectedType reflect.Type
+	}{
+		{
+			TestName:     "IntSlice",
+			Given:        []int{},
+			ExpectedType: reflect.TypeOf(i),
+		},
+		{
+			TestName:     "SimpleStruct",
+			Given:        a,
+			ExpectedType: reflect.TypeOf(a),
+		},
+		{
+			TestName:     "Slice",
+			Given:        []A{},
+			ExpectedType: reflect.TypeOf(a),
+		},
+		{
+			TestName:     "SliceOfPointers",
+			Given:        []*A{},
+			ExpectedType: reflect.TypeOf(a),
+		},
+		{
+			TestName:     "AddressOfSlice",
+			Given:        &[]*A{},
+			ExpectedType: reflect.TypeOf(a),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			actualType := UnderlyingType(tc.Given)
+			if actualType != tc.ExpectedType {
+				t.Errorf("expected %s, got %s", actualType, tc.ExpectedType)
+			}
+		})
+	}
+}

--- a/sqlx.go
+++ b/sqlx.go
@@ -941,7 +941,8 @@ func scanAll(rows rowsi, dest interface{}, structOnly bool) error {
 		fields := m.TraversalsByName(base, columns)
 		// if we are not unsafe and are missing fields, return an error
 		if f, err := missingFields(fields); err != nil && !isUnsafe(rows) {
-			return fmt.Errorf("missing destination name %s in %T", columns[f], dest)
+			destType := reflectx.UnderlyingType(dest).String()
+			return fmt.Errorf("missing destination field '%s' in %s", columns[f], destType)
 		}
 		values = make([]interface{}, len(columns))
 

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1327,6 +1327,54 @@ func TestMissingDestination(t *testing.T) {
 	})
 }
 
+func TestResolveAsterisk(t *testing.T) {
+	testCases := []struct {
+		TestName       string
+		GivenStatement string
+	}{
+		{
+			TestName:       "SimpleSelect",
+			GivenStatement: `SELECT first_name FROM person`,
+		},
+		{
+			TestName:       "AsteriskSelect",
+			GivenStatement: `SELECT * FROM person`,
+		},
+		{
+			TestName: "AsteriskSelectNewline",
+			GivenStatement: `
+SELECT *
+FROM person`,
+		},
+		{
+			TestName: "AsteriskSelectComplexFormatting",
+			GivenStatement: `
+    SELECT
+     *
+    FROM
+     person`,
+		},
+	}
+
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T) {
+		loadDefaultFixture(db, t)
+		for _, tc := range testCases {
+			t.Run(tc.TestName, func(t *testing.T) {
+				var people []Person3
+				err := db.SelectResolveAsterisk(&people, tc.GivenStatement)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, p := range people {
+					if len(p.FirstName) == 0 {
+						t.Errorf("Expected non-zero lengthed first name.")
+					}
+				}
+			})
+		}
+	})
+}
+
 type Product struct {
 	ProductID int
 }


### PR DESCRIPTION
This PR is based on https://github.com/jmoiron/sqlx/pull/407. This first commit is the same, so I would like to resolve the other one first. Maybe we merge both or none of them, but any changes to the first commit obviously will affect both pull requests.

I noticed an interesting class of errors that appeared on my company's project when rolling back the system to a previous commit without also rolling back the DB migrations. When using 'SELECT *' statements, after the rollback you can find yourself in the situation where the DB has new fields that the old structs cannot handle anymore. So I tried implementing a solution to remedy this situation:

Basically, look at all the `db:"..."` tags on the receiving struct and allow the user to replace the asterisk which the specific tags from the struct. So `SelectResolveAsterisk` will shift the responsibility of resolving the asterisk from the DB driver to the Go code to only select for columns that have a destination. For statements without an asterisk select, the method behaves exactly like Select.