### PR TITLE
Adding reset function based on issue

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -589,6 +589,12 @@ func (r *Rows) MapScan(dest map[string]interface{}) error {
 	return MapScan(r, dest)
 }
 
+// ResetMappingCache Resets the mapping cache. This is needed when working with multiple result sets
+// with different underlying structure.
+func (r *Rows) ResetMappingCache() {
+	r.started = false
+}
+
 // StructScan is like sql.Rows.Scan, but scans a single Row into a single Struct.
 // Use this and iterate over Rows manually when the memory load of Select() might be
 // prohibitive.  *Rows.StructScan caches the reflect work of matching up column


### PR DESCRIPTION
Re: #380 Here is a pull request to add a function that resets the cache so multiple result sets can allow StructScan.  This is based on @g-rad's approach.