### PR TITLE
Don't copy sql.Stmt because this also copies the mutex closemu

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -471,8 +471,6 @@ func (tx *Tx) Stmtx(stmt interface{}) *Stmt {
 		s = v.Stmt
 	case *Stmt:
 		s = v.Stmt
-	case sql.Stmt:
-		s = &v
 	case *sql.Stmt:
 		s = v
 	default:

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -217,8 +217,6 @@ func (tx *Tx) StmtxContext(ctx context.Context, stmt interface{}) *Stmt {
 		s = v.Stmt
 	case *Stmt:
 		s = v.Stmt
-	case sql.Stmt:
-		s = &v
 	case *sql.Stmt:
 		s = v
 	default:


### PR DESCRIPTION
Found via static code analyzer.  When passed-in stmt is of type sql.Stmt, the switch makes a copy of it (v) which also copies the sync.RWMutex field "closemu", but we shouldn't be copying mutex values.  It seems like the simplest fix is to just get rid of this switch case since the doc comment for both of the changed functions indicates that they only accept *sql.Stmt or *Stmt anyway.