### PR TITLE
fix reflectx dominant field

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -431,9 +431,14 @@ QueueLoop:
 
 	flds := &StructMap{Index: m, Tree: root, Paths: map[string]*FieldInfo{}, Names: map[string]*FieldInfo{}}
 	for _, fi := range flds.Index {
-		flds.Paths[fi.Path] = fi
-		if fi.Name != "" && !fi.Embedded {
-			flds.Names[fi.Path] = fi
+		// check if nothing has already been pushed with the same path
+		// sometimes you can choose to override a type using embedded struct
+		fld, ok := flds.Paths[fi.Path]
+		if !ok || fld.Embedded {
+			flds.Paths[fi.Path] = fi
+			if fi.Name != "" && !fi.Embedded {
+				flds.Names[fi.Path] = fi
+			}
 		}
 	}
 

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -141,12 +141,51 @@ func TestBasicEmbeddedWithTags(t *testing.T) {
 	// }
 
 	v := m.FieldByName(zv, "a")
-	if ival(v) != z.Bar.Foo.A { // the dominant field
-		t.Errorf("Expecting %d, got %d", z.Bar.Foo.A, ival(v))
+	if ival(v) != z.A { // the dominant field
+		t.Errorf("Expecting %d, got %d", z.A, ival(v))
 	}
 	v = m.FieldByName(zv, "b")
 	if ival(v) != z.B {
 		t.Errorf("Expecting %d, got %d", z.B, ival(v))
+	}
+}
+
+func TestBasicEmbeddedWithSameName(t *testing.T) {
+	type Foo struct {
+		A   int `db:"a"`
+		Foo int `db:"Foo"` // Same name as the embedded struct
+	}
+
+	type FooExt struct {
+		Foo
+		B int `db:"b"`
+	}
+
+	m := NewMapper("db")
+
+	z := FooExt{}
+	z.A = 1
+	z.B = 2
+	z.Foo.Foo = 3
+
+	zv := reflect.ValueOf(z)
+	fields := m.TypeMap(reflect.TypeOf(z))
+
+	if len(fields.Index) != 4 {
+		t.Errorf("Expecting 3 fields, found %d", len(fields.Index))
+	}
+
+	v := m.FieldByName(zv, "a")
+	if ival(v) != z.A { // the dominant field
+		t.Errorf("Expecting %d, got %d", z.A, ival(v))
+	}
+	v = m.FieldByName(zv, "b")
+	if ival(v) != z.B {
+		t.Errorf("Expecting %d, got %d", z.B, ival(v))
+	}
+	v = m.FieldByName(zv, "Foo")
+	if ival(v) != z.Foo.Foo {
+		t.Errorf("Expecting %d, got %d", z.Foo.Foo, ival(v))
 	}
 }
 


### PR DESCRIPTION
From this commit (, the dominant field has been changed and it broke the normal behavior of embedded structs.
Should be like json unmarshaling, if the field "a" must be the first occurrence of A.

#139