### PR TITLE
Add go.mod and go.sum for go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/jmoiron/sqlx
+
+require (
+	github.com/go-sql-driver/mysql v1.4.0
+	github.com/lib/pq v1.0.0
+	github.com/mattn/go-sqlite3 v1.9.0
+	google.golang.org/appengine v1.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
+github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
+github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
+github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
 https://github.com/lib/pq/releases/tag/v1.0.0 was tagged v1.0.0 and with a `go.mod` file just now. I believe it's good time to add it to sqlx now.

I added the `go.mod` file with `go1.11rc1 mod init github.com/jmoiron/sqlx` then run `go1.11rc1 test all` it add all the dependencies and generate the `go.sum` with hashes of theses dependencies. I didn't test with `mysql` that i've not installed.

I think after that sqlx should be tagged with a semver compatible version.