### PR TITLE
adds support for structscan in multiple resultset queries

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -589,6 +589,16 @@ func (r *Rows) MapScan(dest map[string]interface{}) error {
 	return MapScan(r, dest)
 }
 
+// NextResultSet moves to the next resultset if available and resets the field cache.
+func (r *Rows) NextResultSet() bool {
+	if !r.Rows.NextResultSet() {
+		return false
+	}
+	// reset fields cache
+	r.started = false
+	return true
+}
+
 // StructScan is like sql.Rows.Scan, but scans a single Row into a single Struct.
 // Use this and iterate over Rows manually when the memory load of Select() might be
 // prohibitive.  *Rows.StructScan caches the reflect work of matching up column


### PR DESCRIPTION
StructScan fails in a multiple result set scenario when the result sets have different row layouts.

Currently sqlx is unaware of iteration over multiple result sets and uses the first call to StructScan to set a field cache for performance reasons. When a next result set is iterated over, this field cache will most likely not match the struct provided.

By wrapping the NextResultSet method from sql.Rows and setting the field cache `started` property back to false the problem is solved.