### PR TITLE
Added note on minimum Go version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ explains how to use `database/sql` along with sqlx.
 
 ## Recent Changes
 
+* The [introduction](https://github.com/jmoiron/sqlx/pull/387) of `sql.ColumnType` sets the required minimum Go version to 1.8.
+
 * sqlx/types.JsonText has been renamed to JSONText to follow Go naming conventions.
 
 This breaks backwards compatibility, but it's in a way that is trivially fixable


### PR DESCRIPTION
Added a note that with types.JSONText sqlx requires at least Go version 1.8