### PR TITLE
Proposition: more robust compileNamedQuery & Rebind

### DIFF
--- a/named.go
+++ b/named.go
@@ -13,11 +13,10 @@ package sqlx
 //
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
-	"unicode"
+	"strings"
 
 	"github.com/jmoiron/sqlx/reflectx"
 )
@@ -129,7 +128,7 @@ type namedPreparer interface {
 
 func prepareNamed(p namedPreparer, query string) (*NamedStmt, error) {
 	bindType := BindType(p.DriverName())
-	q, args, err := compileNamedQuery([]byte(query), bindType)
+	q, args, err := compileNamedQuery(query, bindType)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +194,7 @@ func bindMapArgs(names []string, arg map[string]interface{}) ([]interface{}, err
 // The rules for binding field names to parameter names follow the same
 // conventions as for StructScan, including obeying the `db` struct tags.
 func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper) (string, []interface{}, error) {
-	bound, names, err := compileNamedQuery([]byte(query), bindType)
+	bound, names, err := compileNamedQuery(query, bindType)
 	if err != nil {
 		return "", []interface{}{}, err
 	}
@@ -210,7 +209,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 
 // bindMap binds a named parameter query with a map of arguments.
 func bindMap(bindType int, query string, args map[string]interface{}) (string, []interface{}, error) {
-	bound, names, err := compileNamedQuery([]byte(query), bindType)
+	bound, names, err := compileNamedQuery(query, bindType)
 	if err != nil {
 		return "", []interface{}{}, err
 	}
@@ -221,96 +220,47 @@ func bindMap(bindType int, query string, args map[string]interface{}) (string, [
 
 // -- Compilation of Named Queries
 
-// Allow digits and letters in bind params;  additionally runes are
-// checked against underscores, meaning that bind params can have be
-// alphanumeric with underscores.  Mind the difference between unicode
-// digits and numbers, where '5' is a digit but '五' is not.
-var allowedBindRunes = []*unicode.RangeTable{unicode.Letter, unicode.Digit}
-
-// FIXME: this function isn't safe for unicode named params, as a failing test
-// can testify.  This is not a regression but a failure of the original code
-// as well.  It should be modified to range over runes in a string rather than
-// bytes, even though this is less convenient and slower.  Hopefully the
-// addition of the prepared NamedStmt (which will only do this once) will make
-// up for the slightly slower ad-hoc NamedExec/NamedQuery.
-
-// compile a NamedQuery into an unbound query (using the '?' bindvar) and
+// compile a NamedQuery into a unbound query (using the '?' bindvar) and
 // a list of names.
-func compileNamedQuery(qs []byte, bindType int) (query string, names []string, err error) {
+func compileNamedQuery(qs string, bindType int) (query string, names []string, err error) {
+	rebound := strings.Builder{}
 	names = make([]string, 0, 10)
-	rebound := make([]byte, 0, len(qs))
-
-	inName := false
-	last := len(qs) - 1
 	currentVar := 1
-	name := make([]byte, 0, 10)
+	byteOffset := 0
 
-	for i, b := range qs {
-		// a ':' while we're in a name is an error
-		if b == ':' {
-			// if this is the second ':' in a '::' escape sequence, append a ':'
-			if inName && i > 0 && qs[i-1] == ':' {
-				rebound = append(rebound, ':')
-				inName = false
-				continue
-			} else if inName {
-				err = errors.New("unexpected `:` while reading named param at " + strconv.Itoa(i))
-				return query, names, err
-			}
-			inName = true
-			name = []byte{}
-		} else if inName && i > 0 && b == '=' {
-			rebound = append(rebound, ':', '=')
-			inName = false
-			continue
-			// if we're in a name, and this is an allowed character, continue
-		} else if inName && (unicode.IsOneOf(allowedBindRunes, rune(b)) || b == '_' || b == '.') && i != last {
-			// append the byte to the name if we are in a name and not on the last byte
-			name = append(name, b)
-			// if we're in a name and it's not an allowed character, the name is done
-		} else if inName {
-			inName = false
-			// if this is the final byte of the string and it is part of the name, then
-			// make sure to add it to the name
-			if i == last && unicode.IsOneOf(allowedBindRunes, rune(b)) {
-				name = append(name, b)
-			}
-			// add the string representation to the names list
-			names = append(names, string(name))
-			// add a proper bindvar for the bindType
+	lex := lexSQL(qs)
+	for tok := range lex.items {
+		isBindVar := tok.typ == itemIdentifier &&
+			tok.val[0] == ':' &&
+			len(tok.val) > 1 &&
+			tok.val[1] != ':'
+		if isBindVar {
+			name := tok.val[1:]
+			names = append(names, name)
+			rebound.WriteString(qs[byteOffset:tok.pos])
 			switch bindType {
 			// oracle only supports named type bind vars even for positional
 			case NAMED:
-				rebound = append(rebound, ':')
-				rebound = append(rebound, name...)
+				rebound.WriteString(tok.val)
 			case QUESTION, UNKNOWN:
-				rebound = append(rebound, '?')
+				rebound.WriteByte('?')
 			case DOLLAR:
-				rebound = append(rebound, '$')
-				for _, b := range strconv.Itoa(currentVar) {
-					rebound = append(rebound, byte(b))
-				}
+				rebound.WriteByte('$')
+				rebound.WriteString(strconv.Itoa(currentVar))
 				currentVar++
 			case AT:
-				rebound = append(rebound, '@', 'p')
-				for _, b := range strconv.Itoa(currentVar) {
-					rebound = append(rebound, byte(b))
-				}
+				rebound.WriteString("@p")
+				rebound.WriteString(strconv.Itoa(currentVar))
 				currentVar++
 			}
-			// add this byte to string unless it was not part of the name
-			if i != last {
-				rebound = append(rebound, b)
-			} else if !unicode.IsOneOf(allowedBindRunes, rune(b)) {
-				rebound = append(rebound, b)
-			}
-		} else {
-			// this is a normal byte and should just go onto the rebound query
-			rebound = append(rebound, b)
+			byteOffset = tok.pos + len(tok.val)
 		}
 	}
-
-	return string(rebound), names, err
+	if byteOffset == 0 {
+		return qs, names, err
+	}
+	rebound.WriteString(qs[byteOffset:])
+	return rebound.String(), names, err
 }
 
 // BindNamed binds a struct or a map to a query with named parameters.

--- a/named.go
+++ b/named.go
@@ -128,10 +128,7 @@ type namedPreparer interface {
 
 func prepareNamed(p namedPreparer, query string) (*NamedStmt, error) {
 	bindType := BindType(p.DriverName())
-	q, args, err := compileNamedQuery(query, bindType)
-	if err != nil {
-		return nil, err
-	}
+	q, args := compileNamedQuery(query, bindType)
 	stmt, err := Preparex(p, q)
 	if err != nil {
 		return nil, err
@@ -194,10 +191,7 @@ func bindMapArgs(names []string, arg map[string]interface{}) ([]interface{}, err
 // The rules for binding field names to parameter names follow the same
 // conventions as for StructScan, including obeying the `db` struct tags.
 func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper) (string, []interface{}, error) {
-	bound, names, err := compileNamedQuery(query, bindType)
-	if err != nil {
-		return "", []interface{}{}, err
-	}
+	bound, names := compileNamedQuery(query, bindType)
 
 	arglist, err := bindArgs(names, arg, m)
 	if err != nil {
@@ -209,10 +203,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 
 // bindMap binds a named parameter query with a map of arguments.
 func bindMap(bindType int, query string, args map[string]interface{}) (string, []interface{}, error) {
-	bound, names, err := compileNamedQuery(query, bindType)
-	if err != nil {
-		return "", []interface{}{}, err
-	}
+	bound, names := compileNamedQuery(query, bindType)
 
 	arglist, err := bindMapArgs(names, args)
 	return bound, arglist, err
@@ -222,7 +213,7 @@ func bindMap(bindType int, query string, args map[string]interface{}) (string, [
 
 // compile a NamedQuery into a unbound query (using the '?' bindvar) and
 // a list of names.
-func compileNamedQuery(qs string, bindType int) (query string, names []string, err error) {
+func compileNamedQuery(qs string, bindType int) (query string, names []string) {
 	rebound := strings.Builder{}
 	names = make([]string, 0, 10)
 	currentVar := 1
@@ -257,10 +248,10 @@ func compileNamedQuery(qs string, bindType int) (query string, names []string, e
 		}
 	}
 	if byteOffset == 0 {
-		return qs, names, err
+		return qs, names
 	}
 	rebound.WriteString(qs[byteOffset:])
-	return rebound.String(), names, err
+	return rebound.String(), names
 }
 
 // BindNamed binds a struct or a map to a query with named parameters.

--- a/named_context.go
+++ b/named_context.go
@@ -16,10 +16,7 @@ type namedPreparerContext interface {
 
 func prepareNamedContext(ctx context.Context, p namedPreparerContext, query string) (*NamedStmt, error) {
 	bindType := BindType(p.DriverName())
-	q, args, err := compileNamedQuery(query, bindType)
-	if err != nil {
-		return nil, err
-	}
+	q, args := compileNamedQuery(query, bindType)
 	stmt, err := PreparexContext(ctx, p, q)
 	if err != nil {
 		return nil, err

--- a/named_context.go
+++ b/named_context.go
@@ -16,7 +16,7 @@ type namedPreparerContext interface {
 
 func prepareNamedContext(ctx context.Context, p namedPreparerContext, query string) (*NamedStmt, error) {
 	bindType := BindType(p.DriverName())
-	q, args, err := compileNamedQuery([]byte(query), bindType)
+	q, args, err := compileNamedQuery(query, bindType)
 	if err != nil {
 		return nil, err
 	}

--- a/named_test.go
+++ b/named_test.go
@@ -71,10 +71,7 @@ func TestCompileQuery(t *testing.T) {
 	}
 
 	for _, test := range table {
-		qr, names, err := compileNamedQuery(test.Q, QUESTION)
-		if err != nil {
-			t.Error(err)
-		}
+		qr, names := compileNamedQuery(test.Q, QUESTION)
 		if qr != test.R {
 			t.Errorf("expected %s, got %s", test.R, qr)
 		}
@@ -87,17 +84,17 @@ func TestCompileQuery(t *testing.T) {
 				}
 			}
 		}
-		qd, _, _ := compileNamedQuery(test.Q, DOLLAR)
+		qd, _ := compileNamedQuery(test.Q, DOLLAR)
 		if qd != test.D {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`", test.D, qd)
 		}
 
-		qt, _, _ := compileNamedQuery(test.Q, AT)
+		qt, _ := compileNamedQuery(test.Q, AT)
 		if qt != test.T {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`", test.T, qt)
 		}
 
-		qq, _, _ := compileNamedQuery(test.Q, NAMED)
+		qq, _ := compileNamedQuery(test.Q, NAMED)
 		if qq != test.N {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`\n(len: %d vs %d)", test.N, qq, len(test.N), len(qq))
 		}

--- a/named_test.go
+++ b/named_test.go
@@ -29,7 +29,7 @@ func TestCompileQuery(t *testing.T) {
 			V: []string{"name1", "name2"},
 		},
 		{
-			Q: `SELECT "::foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			Q: `SELECT ":foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
 			R: `SELECT ":foo" FROM a WHERE first_name=? AND last_name=?`,
 			D: `SELECT ":foo" FROM a WHERE first_name=$1 AND last_name=$2`,
 			T: `SELECT ":foo" FROM a WHERE first_name=@p1 AND last_name=@p2`,
@@ -37,7 +37,7 @@ func TestCompileQuery(t *testing.T) {
 			V: []string{"name1", "name2"},
 		},
 		{
-			Q: `SELECT 'a::b::c' || first_name, '::::ABC::_::' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
+			Q: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
 			R: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=? AND last_name=?`,
 			D: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=$1 AND last_name=$2`,
 			T: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=@p1 AND last_name=@p2`,
@@ -52,20 +52,26 @@ func TestCompileQuery(t *testing.T) {
 			T: `SELECT @name := "name", @p1, @p2, @p3`,
 			V: []string{"age", "first", "last"},
 		},
-		/* This unicode awareness test sadly fails, because of our byte-wise worldview.
-		 * We could certainly iterate by Rune instead, though it's a great deal slower,
-		 * it's probably the RightWay(tm)
 		{
 			Q: `INSERT INTO foo (a,b,c,d) VALUES (:あ, :b, :キコ, :名前)`,
 			R: `INSERT INTO foo (a,b,c,d) VALUES (?, ?, ?, ?)`,
 			D: `INSERT INTO foo (a,b,c,d) VALUES ($1, $2, $3, $4)`,
-			N: []string{"name", "age", "first", "last"},
+			N: `INSERT INTO foo (a,b,c,d) VALUES (:あ, :b, :キコ, :名前)`,
+			T: `INSERT INTO foo (a,b,c,d) VALUES (@p1, @p2, @p3, @p4)`,
+			V: []string{"あ", "b", "キコ", "名前"},
 		},
-		*/
+		{
+			Q: `SELECT @name /* a block :comment /* with nesting */*/ := ":name", 'quote', :age, :first, :last`,
+			R: `SELECT @name /* a block :comment /* with nesting */*/ := ":name", 'quote', ?, ?, ?`,
+			D: `SELECT @name /* a block :comment /* with nesting */*/ := ":name", 'quote', $1, $2, $3`,
+			N: `SELECT @name /* a block :comment /* with nesting */*/ := ":name", 'quote', :age, :first, :last`,
+			T: `SELECT @name /* a block :comment /* with nesting */*/ := ":name", 'quote', @p1, @p2, @p3`,
+			V: []string{"age", "first", "last"},
+		},
 	}
 
 	for _, test := range table {
-		qr, names, err := compileNamedQuery([]byte(test.Q), QUESTION)
+		qr, names, err := compileNamedQuery(test.Q, QUESTION)
 		if err != nil {
 			t.Error(err)
 		}
@@ -81,17 +87,17 @@ func TestCompileQuery(t *testing.T) {
 				}
 			}
 		}
-		qd, _, _ := compileNamedQuery([]byte(test.Q), DOLLAR)
+		qd, _, _ := compileNamedQuery(test.Q, DOLLAR)
 		if qd != test.D {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`", test.D, qd)
 		}
 
-		qt, _, _ := compileNamedQuery([]byte(test.Q), AT)
+		qt, _, _ := compileNamedQuery(test.Q, AT)
 		if qt != test.T {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`", test.T, qt)
 		}
 
-		qq, _, _ := compileNamedQuery([]byte(test.Q), NAMED)
+		qq, _, _ := compileNamedQuery(test.Q, NAMED)
 		if qq != test.N {
 			t.Errorf("\nexpected: `%s`\ngot:      `%s`\n(len: %d vs %d)", test.N, qq, len(test.N), len(qq))
 		}

--- a/sqltokenizer.go
+++ b/sqltokenizer.go
@@ -1,0 +1,345 @@
+package sqlx
+
+// This file implements an overly simplified SQL tokenizer (or lexer). It
+// only recognizes and emits the following tokens:
+//
+//     Space:             runs of whitespace characters
+//     Comment:           '--' comment line
+//     BlockComment:      /* */ block comment (nests!)
+//     Identifier:        any identifier (keywords too)
+//     QuotedIdentifier:  quoted (") identifier
+//     StringLiteral:     quoted (') string
+//     Numeric:           a numeric constant
+//     Operator:          of which parenthesis, comma, ...
+//
+// The syntax rules come from the PostgreSQL v10 documentation:
+// https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html
+// However no PostgreSQL specific syntax elements are used. This lexer
+// tries to be as close to sql-2003 as possible.
+//
+// Here is the list of lexical rules that are implemented in this file:
+//
+//     - An Identifier is a run of non-space characters, which matches
+//       non of the other tokens.
+//     - An Identifier token always ends upon encountering one of the
+//       following characters (which is not included):
+//       ' " ( ) [ ] , ; $ : . + - * / < > = ~ ! @ # % ^ & | ` ?
+//   !!! SPECIAL RULE for sqlx: '.' is a valid identifier character used
+//       when binding struct parameters.
+//     - An operator token is one of the following (order of priority):
+//       ??( ??)
+//       <= <> >= || :: .. -> !=
+//       ( ) [ ] , ; . + - ^ * / % < > =
+//     - A period (.) followed by a digit is the start of a Numeric. It
+//       is not considered an Operator.
+//     - A minus directly followed by a second minus is the start of a
+//       Comment. It is not considered an Operator.
+//     - A solidus (/) directly followed by an asterisk is the start of
+//       a BlockComment. It is not considered an Operator.
+//     - A QuotedIdentifier starts at a doublequote character ("), and
+//       ends at the first following doublequote character which is
+//       not escaped (doubled).
+//     - A StringLiteral starts at a quote character ("), and ends at
+//       the first following quote character which is not escaped
+//       (doubled).
+//     - A Comment starts from the double minus, and goes until the
+//       first newline character (inclusive).
+//     - A BlockComment starts at the '/*' combination, and ends at the
+//       matching '*/' combination: these pairs may nest.
+//
+// The operators come from:
+// https://ronsavage.github.io/SQL/sql-2003-2.bnf.html#xref-delimiter%20token
+// https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-OPERATORS
+//
+// For the application I need there are too many token types, however
+// implementation wise it would not be simpler to have less.
+
+// The implementation is highly inspired by the standard library
+// text/template/parse lexer, with the difference that it ranges of bytes
+// instead of UTF8 runes. This simplification works because all of the
+// SQL special characters are ASCII, and thanks to the nice property of
+// UTF8 which guarantees that bytes representing valid ASCII characters
+// must represent themselves.
+
+import "strings"
+
+type item struct {
+	typ itemType // type of this item
+	pos int      // starting position, in bytes, of this item
+	val string   // value of this item
+}
+
+func (i item) String() string {
+	switch i.typ {
+	case itemEOF:
+		return "<EOF>"
+	case itemIdentifier:
+		return "<Identifier>   " + string(i.val)
+	case itemQuotedIdentifier:
+		return `<"Identifier"> ` + string(i.val)
+	case itemStringLiteral:
+		return "<String>       " + string(i.val)
+	case itemSpace:
+		return "<Space>"
+	case itemOperator:
+		return "<Operator>     " + string(i.val)
+	case itemNumeric:
+		return "<Numeric>      " + string(i.val)
+	case itemComment:
+		return "<Comment>      " + string(i.val)
+	case itemBlockComment:
+		return "<BlockComment> " + string(i.val)
+	default:
+		return "<unknown>      " + string(i.val)
+	}
+}
+
+type itemType int
+
+const (
+	itemEOF          itemType = iota
+	itemSpace
+	itemComment
+	itemBlockComment
+	itemIdentifier
+	itemQuotedIdentifier
+	itemStringLiteral
+	itemNumeric
+	itemOperator
+)
+
+type stateFn func(*lexer) stateFn
+
+type lexer struct {
+	input string    // input string to be tokenized
+	pos   int       // current position in the input, in bytes
+	start int       // start position of the current item, in bytes
+	items chan item // channel of scanned items
+
+	commentDepth int // current depth of nested block comment
+}
+
+var (
+	spaceChars = " \t\r\n"
+	operatorStart = "?()<=>|:.![],;+-^*/%"
+	delimiters = spaceChars + "'\"()[],;$:+-*/<>=~!@#%^&|`?"
+	oneCharOps = "()[],;.+-^*/%<>="
+)
+
+// lexSQL is the only function you should use outside this file.
+// Example usage:
+//
+//     var query string
+//     lex := lexSQL(query)
+//     for token := range lex.items {
+//             switch token.typ {
+//             case itemIdentifier:
+//                     println(token.val)
+//             }
+//     }
+func lexSQL(input string) *lexer {
+	l := &lexer{
+		input: input,
+		items: make(chan item),
+	}
+	go l.run()
+	return l
+}
+
+const eof = -1
+
+// next returns the next byte cast to a rune, using -1 for EOF.
+// There is no need to actually the UTF8 byte sequences: we are only
+// interested in valid ASCII characters.
+func (l *lexer) next() rune {
+	r := rune(0)
+	if l.pos >= len(l.input) {
+		r = eof
+	} else {
+		r = rune(l.input[l.pos])
+	}
+	l.pos++
+	return r
+}
+
+func (l *lexer) backup() {
+	l.pos--
+}
+
+func (l *lexer) peek() rune {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	return rune(l.input[l.pos])
+}
+
+func (l *lexer) emit(t itemType) {
+	if l.pos > len(l.input) {
+		l.pos = len(l.input)
+	}
+	l.items <- item{t, l.start, l.input[l.start:l.pos]}
+	l.start = l.pos
+}
+
+func (l *lexer) run() {
+	for state := lexAny; state != nil; {
+		state = state(l)
+	}
+	close(l.items)
+}
+
+func lexAny(l *lexer) stateFn {
+	c := l.next()
+	switch c {
+	case eof:
+		l.emit(itemEOF)
+		return nil
+	case '\'':
+		return lexSingleQuoted
+	case '"':
+		return lexDoubleQuoted
+	case '-':
+		if l.peek() == '-' {
+			l.next()
+			return lexComment
+		}
+	case '/':
+		if l.peek() == '*' {
+			l.next()
+			return lexBlockComment
+		}
+	case '.':
+		if n := l.peek(); n >= '0' && n <= '9' {
+			return lexNumeric
+		}
+	}
+	if c >= '0' && c <= '9' {
+		return lexNumeric
+	}
+	if strings.IndexRune(spaceChars, c) >= 0 {
+		return lexSpace
+	}
+	if strings.IndexRune(operatorStart, c) >= 0 {
+		return lexOperator
+	}
+	return lexIdentifier
+}
+
+func lexSpace(l *lexer) stateFn {
+	for strings.IndexRune(spaceChars, l.next()) >= 0 {
+	}
+	l.backup()
+	l.emit(itemSpace)
+	return lexAny
+}
+
+func lexOperator(l *lexer) stateFn {
+	in := l.input[l.start:]
+	if len(in) >= 3 && strings.HasPrefix(in, "??") {
+		if in[2] == '(' || in[2] == ')' {
+			l.pos += 2
+			l.emit(itemOperator)
+			return lexAny
+		}
+	}
+	if len(in) >= 2 {
+		switch string(in[:2]) {
+		case "<=", "<>", ">=", "||", "::", "..", "->", "!=":
+			l.pos += 1
+			l.emit(itemOperator)
+			return lexAny
+		}
+	}
+	if strings.IndexByte(oneCharOps, in[0]) >= 0 {
+		l.emit(itemOperator)
+		return lexAny
+	}
+	return lexIdentifier
+}
+
+func lexIdentifier(l *lexer) stateFn {
+	for {
+		c := l.next()
+		if c == eof || strings.IndexRune(delimiters, c) >= 0 {
+			l.backup()
+			l.emit(itemIdentifier)
+			return lexAny
+		}
+	}
+}
+
+func lexQuoted(l *lexer, q byte) stateFn {
+	for {
+		i := strings.IndexByte(l.input[l.pos:], q)
+		if i >= 0 {
+			l.pos += i + 1
+		} else {
+			l.pos = len(l.input)
+		}
+		if l.peek() != rune(q) {
+			break
+		}
+	}
+	l.emit(itemStringLiteral)
+	return lexAny
+}
+
+func lexSingleQuoted(l *lexer) stateFn {
+	return lexQuoted(l, '\'')
+}
+
+func lexDoubleQuoted(l *lexer) stateFn {
+	return lexQuoted(l, '"')
+}
+
+func lexNumeric(l *lexer) stateFn {
+	for {
+		c := l.next()
+		switch {
+		case c >= '0' && c <= '9':
+		default:
+			l.backup()
+			l.emit(itemNumeric)
+			return lexAny
+		}
+	}
+}
+
+// lexComment scans the current comment until the next newline. We know
+// the comment has already started.
+func lexComment(l *lexer) stateFn {
+	if i := strings.IndexByte(l.input[l.pos:], '\n'); i >= 0 {
+		l.pos += i + 1 // consume the newline too
+	} else {
+		l.pos = len(l.input)
+	}
+	l.emit(itemComment)
+	return lexAny
+}
+
+func lexBlockComment(l *lexer) stateFn {
+	depth := 1
+	for {
+		switch l.next() {
+		case eof:
+			l.emit(itemBlockComment)
+			l.emit(itemEOF)
+			return nil
+		case '*':
+			if l.peek() == '/' {
+				l.next()
+				depth--
+			}
+		case '/':
+			if l.peek() == '*' {
+				l.next()
+				depth++
+			}
+		}
+		if depth <= 0 {
+			break
+		}
+	}
+	l.emit(itemBlockComment)
+	return lexAny
+}


### PR DESCRIPTION
Hi!

I would like to propose an implementation of named parameter translation which uses a simplified SQL tokenizer. The main advantages are that non-ascii named parameters now work, and what look like parameters inside quotes and comments are correctly ignored.
However there is a huge impact on performance.

Are the robustness gains worth the speed loss?

_Notes on UTF8_

UTF8 encoding has the nice property that if a byte corresponds to a valid ASCII character, then it represents the same unicode point. Thus to find all question marks `?` in a valid UTF8 string, a simple `bytes.IndexByte(query, '?')` does what you expect.
However to be fully unicode compatible, you need to take into account [combining characters](https://en.wikipedia.org/wiki/Combining_character).
Thus `Rebind` and `rebindBuffer` are equivalent.