### PR TITLE
add support for batch insert/exec with maps in addition to structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 tags
 environ
+
+.idea

--- a/README.md
+++ b/README.md
@@ -182,6 +182,28 @@ func main() {
     // as the name -> db mapping, so struct fields are lowercased and the `db` tag
     // is taken into consideration.
     rows, err = db.NamedQuery(`SELECT * FROM person WHERE first_name=:first_name`, jason)
+    
+    
+    // batch insert
+    
+    // batch insert with structs
+    personStructs := []Person{
+        {FirstName: "Ardie", LastName: "Savea", Email: "asavea@ab.co.nz"},
+        {FirstName: "Sonny Bill", LastName: "Williams", Email: "sbw@ab.co.nz"},
+        {FirstName: "Ngani", LastName: "Laumape", Email: "nlaumape@ab.co.nz"},
+    }
+
+    _, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
+        VALUES (:first_name, :last_name, :email)`, personStructs)
+
+    // batch insert with maps
+    personMaps := []map[string]interface{}{
+        {"first_name": "Ardie", "last_name": "Savea", "email": "asavea@ab.co.nz"},
+        {"first_name": "Sonny Bill", "last_name": "Williams", "email": "sbw@ab.co.nz"},
+        {"first_name": "Ngani", "last_name": "Laumape", "email": "nlaumape@ab.co.nz"},
+    }
+
+    _, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
+        VALUES (:first_name, :last_name, :email)`, personMaps)
 }
 ```
-

--- a/named.go
+++ b/named.go
@@ -157,6 +157,10 @@ func bindAnyArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interfa
 // type, given a list of names to pull out of the struct.  Used by public
 // BindStruct interface.
 func bindArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{}, error) {
+	if maparg, ok := arg.(map[string]interface{}); ok {
+		return bindMapArgs(names, maparg)
+	}
+
 	arglist := make([]interface{}, 0, len(names))
 
 	// grab the indirected value of arg

--- a/named_test.go
+++ b/named_test.go
@@ -184,7 +184,7 @@ func TestNamedQueries(t *testing.T) {
 			t.Errorf("got %s, expected %s", p.Email, people[0].Email)
 		}
 
-		// test batch inserts
+		// test struct batch inserts
 		sls := []Person{
 			{FirstName: "Ardie", LastName: "Savea", Email: "asavea@ab.co.nz"},
 			{FirstName: "Sonny Bill", LastName: "Williams", Email: "sbw@ab.co.nz"},
@@ -193,6 +193,17 @@ func TestNamedQueries(t *testing.T) {
 
 		_, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
 			VALUES (:first_name, :last_name, :email)`, sls)
+		test.Error(err)
+
+		// test map batch inserts
+		slsMap := []map[string]interface{}{
+			{"first_name": "Ardie", "last_name": "Savea", "email": "asavea@ab.co.nz"},
+			{"first_name": "Sonny Bill", "last_name": "Williams", "email": "sbw@ab.co.nz"},
+			{"first_name": "Ngani", "last_name": "Laumape", "email": "nlaumape@ab.co.nz"},
+		}
+
+		_, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
+			VALUES (:first_name, :last_name, :email)`, slsMap)
 		test.Error(err)
 
 		for _, p := range sls {


### PR DESCRIPTION
This is a feature specific use case I have, where I use the same internal logic for importing different tables into a db.

Thus I would like to use the syntax found in the test case added in [named_test.go](named_test.go)

Use case is something like this:

```go
type tableDump struct {
	tableName   string
	tableValues []map[string]interface{}
}

var dump tableDump
// ... read table data into `dump`

dbColKeys := safeParseKeys(dump)
placeholderKeys := prependEach(dbColKeys, ":")

_, err = db.NamedExec("INSERT INTO " + dump.tableName + "(" +
		strings.Join(dbColKeys, ",") + ")" +
		"VALUES " +
		"(" + strings.Join(placeholderKeys, ",") + ")",
                dump.tableValues,
)
```