### PR TITLE
Add function to specify bindtype for driver name

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -20,21 +20,39 @@ const (
 	AT
 )
 
+var (
+	ErrRebind = errors.New("binding already exists")
+
+	bindings = map[string]int{
+		"postgres":         DOLLAR,
+		"pgx":              DOLLAR,
+		"pq-timeouts":      DOLLAR,
+		"cloudsqlpostgres": DOLLAR,
+		"ql":               DOLLAR,
+		"mysql":            QUESTION,
+		"sqlite3":          QUESTION,
+		"oci8":             NAMED,
+		"ora":              NAMED,
+		"goracle":          NAMED,
+		"sqlserver":        AT,
+	}
+)
+
 // BindType returns the bindtype for a given database given a drivername.
 func BindType(driverName string) int {
-	switch driverName {
-	case "postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql":
-		return DOLLAR
-	case "mysql":
-		return QUESTION
-	case "sqlite3":
-		return QUESTION
-	case "oci8", "ora", "goracle":
-		return NAMED
-	case "sqlserver":
-		return AT
+	return bindings[driverName]
+}
+
+// BindDriver binds the bindtype for a given database drivername.
+// Returns ErrRebind if the binding already exists and the bindtype is different from the one supplied
+func BindDriver(driverName string, bindType int) error {
+	current, ok := bindings[driverName]
+	if ok && current != bindType {
+		return ErrRebind
 	}
-	return UNKNOWN
+
+	bindings[driverName] = bindType
+	return nil
 }
 
 // FIXME: this should be able to be tolerant of escaped ?'s in queries without


### PR DESCRIPTION
This allows for specifying the `bindtype` for a given `drivername` when that `drivername` does not already have a `bindtype` specified. This change allows for sqlx to be used with any driver, not just the ones hardcoded. If `BindDriver` is called with parameters that would change an existing binding, `ErrRebind` is thrown.

Example use case:
```
package main

import (
    github.com/jmoiron/sqlx
    _ github.com/lamebear/custom-db-driver
)

func main() {
    err := sqlx.BindDriver("mycustomdriver", sqlx.DOLLAR)
    if err != nil {
        log.Fatal(err)
    }
}
``` 