### PR TITLE
Removed ineffectual assignment

### DIFF
--- a/types/types_test.go
+++ b/types/types_test.go
@@ -35,7 +35,7 @@ func TestJSONText(t *testing.T) {
 	}
 
 	j = JSONText(`{"foo": 1, invalid, false}`)
-	v, err = j.Value()
+	_, err = j.Value()
 	if err == nil {
 		t.Errorf("Was expecting invalid json to fail!")
 	}


### PR DESCRIPTION
We don't test for the value here, so don't assign it.