### PR TITLE
fix: null literals in JSON get unmarshaled as null string's bytes

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -72,6 +72,11 @@ func (j *JSONText) UnmarshalJSON(data []byte) error {
 	if j == nil {
 		return errors.New("JSONText: UnmarshalJSON on nil pointer")
 	}
+
+	if string(data) == "null" {
+		return nil
+	}
+
 	*j = append((*j)[0:0], data...)
 	return nil
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestGzipText(t *testing.T) {
 	g := GzippedText("Hello, world")
@@ -60,6 +63,24 @@ func TestJSONText(t *testing.T) {
 	err = (&j).Scan(v)
 	if err != nil {
 		t.Errorf("Was not expecting an error")
+	}
+}
+
+func TestJSONText_UnmarshalJSON(t *testing.T) {
+	type S struct {
+		NullField JSONText
+		Field string
+	}
+	b := []byte(`{"field": "foo", "nullField": null}`)
+	var s S
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Errorf("Was not expecting an error")
+	}
+	if len(s.NullField) != 0 {
+		t.Errorf("null in JSON should have yielded empty slice")
+	}
+	if s.Field != "foo" {
+		t.Errorf("Failed to unmarshal normal string")
 	}
 }
 


### PR DESCRIPTION
JSONText's Unmarshal misintreprets a null literal as something to unmarshal.

I'm not 100% sure this is correct, definitely looking for feedback. But the root of why I feel like it's behaving wrong is this:

```go
type Foo struct {
  B []byte
  J types.JSONText
}

func main() {
        var f Foo
	fmt.Println("zero of B", f.B)
	fmt.Println("B is nil", f.B == nil)
	fmt.Println("zero of J", f.J)
	fmt.Println("J is nil", f.J == nil)	
	json.Unmarshal([]byte(`{"b": null, "j": null}`), &f)
	fmt.Println("after unmarshal B", f.B)
	fmt.Println("B is nil", f.B == nil)
	fmt.Println("after unmarshal J", f.J)
	fmt.Println("J is nil", f.J == nil)	
}
```

Which outputs:

```
zero of B []
B is nil true
zero of J []
J is nil true
after unmarshal B []
B is nil true
after unmarshal J [110 117 108 108]
J is nil false
```

The bytes `110 117 108 108` are the bytes of "null".

For ease of reproduction: https://play.golang.org/p/neMaVt39bRb