### PR TITLE
Fix #473: handle nil arguments in In()

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -98,24 +98,26 @@ func rebindBuff(bindType int, query string) string {
 	return rqb.String()
 }
 
-func asSliceToExpand(i interface{}) (v reflect.Value, ok bool) {
+func asSliceForIn(i interface{}) (v reflect.Value, ok bool) {
 	if i == nil {
-		ok = false
-		return
+		return reflect.Value{}, false
 	}
 
 	v = reflect.ValueOf(i)
 	t := reflectx.Deref(v.Type())
 
-	// []byte is a driver.Value type so it should not be expanded
-	ok = t.Kind() == reflect.Slice && t != reflect.TypeOf([]byte{})
-
-	if !ok {
-		// Don't return non-expandable values
-		v = reflect.Value{}
+	// Only expand slices
+	if t.Kind() != reflect.Slice {
+		return reflect.Value{}, false
 	}
 
-	return
+	// []byte is a driver.Value type so it should not be expanded
+	if t == reflect.TypeOf([]byte{}) {
+		return reflect.Value{}, false
+
+	}
+
+	return v, true
 }
 
 // In expands slice values in args, returning the modified query string
@@ -140,7 +142,7 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 			arg, _ = a.Value()
 		}
 
-		if v, ok := asSliceToExpand(arg); ok {
+		if v, ok := asSliceForIn(arg); ok {
 			meta[i].length = v.Len()
 			meta[i].v = v
 

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1511,6 +1511,9 @@ func TestIn(t *testing.T) {
 		{"SELECT * FROM foo WHERE x = ? AND y in (?)",
 			[]interface{}{[]byte("foo"), []int{0, 5, 3}},
 			4},
+		{"SELECT * FROM foo WHERE x = ? AND y IN (?)",
+			[]interface{}{sql.NullString{Valid: false}, []string{"a", "b"}},
+			3},
 	}
 	for _, test := range tests {
 		q, a, err := In(test.q, test.args...)


### PR DESCRIPTION
I ran in to #473, and figured out a fix. Please let me know if you'd like any changes to the diff.

Without the nil check in bind.go:102, the test panics with this stack:

```
panic: reflect: call of reflect.Value.Type on zero Value [recovered]
        panic: reflect: call of reflect.Value.Type on zero Value

goroutine 106 [running]:
testing.tRunner.func1(0xc00029e700)
        .../go/src/testing/testing.go:830 +0x392
panic(0x835440, 0xc00030cf20)
        .../go/src/runtime/panic.go:522 +0x1b5
reflect.Value.Type(0x0, 0x0, 0x0, 0xd8e240, 0x840460)
        .../go/src/reflect/value.go:1813 +0x169
github.com/jmoiron/sqlx.asSliceToExpand(0x0, 0x0, 0x0, 0x0, 0x0, 0x1)
        sqlx/bind.go:108 +0xc7
github.com/jmoiron/sqlx.In(0x8a4519, 0x2a, 0xc00030cea0, 0x2, 0x2, 0xc0000a05d0, 0x30, 0xc0000a7d80, 0x4, 0x4, ...)
        sqlx/bind.go:143 +0x127
github.com/jmoiron/sqlx.TestIn(0xc00029e700)
        sqlx/sqlx_test.go:1519 +0x4fa
testing.tRunner(0xc00029e700, 0x8ad6c0)
        .../go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
        .../go/src/testing/testing.go:916 +0x35a
exit status 2
FAIL    github.com/jmoiron/sqlx 2.097s
```