### PR TITLE
Add custom bind types

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -23,15 +23,15 @@ const (
 // BindType returns the bindtype for a given database given a drivername.
 func BindType(driverName string) int {
 	switch driverName {
-	case "postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql":
+	case "postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "custompostgres":
 		return DOLLAR
-	case "mysql":
+	case "mysql", "custommysql":
 		return QUESTION
-	case "sqlite3":
+	case "sqlite3", "customsqlite3":
 		return QUESTION
-	case "oci8", "ora", "goracle":
+	case "oci8", "ora", "goracle", "customoracle":
 		return NAMED
-	case "sqlserver":
+	case "sqlserver", "customsqlserver":
 		return AT
 	}
 	return UNKNOWN


### PR DESCRIPTION
This PR adds custom bind types for each driver so one can easily register a new driver without sqlx code change. This is a crutch till https://github.com/jmoiron/sqlx/pull/520 is added when versioning and such is at a better point.

Related issue: https://github.com/jmoiron/sqlx/issues/559