### PR TITLE
Unify Connect and ConnectContext behaviour: On Ping() error close DB

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -1,6 +1,7 @@
 package sqlx
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -631,16 +632,7 @@ func (r *Rows) StructScan(dest interface{}) error {
 
 // Connect to a database and verify with a ping.
 func Connect(driverName, dataSourceName string) (*DB, error) {
-	db, err := Open(driverName, dataSourceName)
-	if err != nil {
-		return nil, err
-	}
-	err = db.Ping()
-	if err != nil {
-		db.Close()
-		return nil, err
-	}
-	return db, nil
+	return ConnectContext(context.Background(), driverName, dataSourceName)
 }
 
 // MustConnect connects to a database and panics on error.

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -18,7 +18,11 @@ func ConnectContext(ctx context.Context, driverName, dataSourceName string) (*DB
 		return db, err
 	}
 	err = db.PingContext(ctx)
-	return db, err
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
 }
 
 // QueryerContext is an interface used by GetContext and SelectContext


### PR DESCRIPTION
Connect() and ConnectContext() returned different results when Ping()ing the database failed - Connect() closed the DB and returned nil, error, while ConnectContext() returned the DB and an error.

Basically, the same as #370, but for ConnectContext instead of Connect.