### PR TITLE
Improve parsing of named parameters

### DIFF
--- a/named.go
+++ b/named.go
@@ -314,9 +314,8 @@ const (
 // a list of names.
 func compileNamedQuery(qs []byte, bindType int) (query string, names []string, err error) {
 	var result strings.Builder
-
-	paramCount := 1
 	var params []string
+
 	addParam := func(paramName string) {
 		params = append(params, paramName)
 
@@ -329,13 +328,11 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 			result.WriteByte('?')
 		case DOLLAR:
 			result.WriteByte('$')
-			result.WriteString(strconv.Itoa(paramCount))
+			result.WriteString(strconv.Itoa(len(params)))
 		case AT:
 			result.WriteString("@p")
-			result.WriteString(strconv.Itoa(paramCount))
+			result.WriteString(strconv.Itoa(len(params)))
 		}
-
-		paramCount++
 	}
 
 	isRuneStartOfIdent := func(r rune) bool {

--- a/named.go
+++ b/named.go
@@ -341,8 +341,12 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 		paramCount++
 	}
 
+	isRuneStartOfIdent := func(r rune) bool {
+		return unicode.In(r, unicode.Letter) || r == '_'
+	}
+
 	isRunePartOfIdent := func(r rune) bool {
-		return unicode.In(r, allowedBindRunes...) || r == '_' || r == '.'
+		return isRuneStartOfIdent(r) || unicode.In(r, allowedBindRunes...) || r == '_' || r == '.'
 	}
 
 	source := string(qs)
@@ -368,7 +372,7 @@ func compileNamedQuery(qs []byte, bindType int) (query string, names []string, e
 		addCurrentRune := true
 		switch ctx.state {
 		case parseStateQuery:
-			if currentRune == colon && previousRune != colon && isRunePartOfIdent(nextRune) {
+			if currentRune == colon && previousRune != colon && isRuneStartOfIdent(nextRune) {
 				// :foo
 				addCurrentRune = false
 				setState(parseStateConsumingIdent, map[string]interface{}{

--- a/named_test.go
+++ b/named_test.go
@@ -29,7 +29,7 @@ func TestCompileQuery(t *testing.T) {
 			V: []string{"name1", "name2"},
 		},
 		{
-			Q: `SELECT "::foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
+			Q: `SELECT ":foo" FROM a WHERE first_name=:name1 AND last_name=:name2`,
 			R: `SELECT ":foo" FROM a WHERE first_name=? AND last_name=?`,
 			D: `SELECT ":foo" FROM a WHERE first_name=$1 AND last_name=$2`,
 			T: `SELECT ":foo" FROM a WHERE first_name=@p1 AND last_name=@p2`,
@@ -37,11 +37,11 @@ func TestCompileQuery(t *testing.T) {
 			V: []string{"name1", "name2"},
 		},
 		{
-			Q: `SELECT 'a::b::c' || first_name, '::::ABC::_::' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
-			R: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=? AND last_name=?`,
-			D: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=$1 AND last_name=$2`,
-			T: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=@p1 AND last_name=@p2`,
-			N: `SELECT 'a:b:c' || first_name, '::ABC:_:' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
+			Q: `SELECT 'a:b:c' || first_name, ':ABC:_:' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
+			R: `SELECT 'a:b:c' || first_name, ':ABC:_:' FROM person WHERE first_name=? AND last_name=?`,
+			D: `SELECT 'a:b:c' || first_name, ':ABC:_:' FROM person WHERE first_name=$1 AND last_name=$2`,
+			T: `SELECT 'a:b:c' || first_name, ':ABC:_:' FROM person WHERE first_name=@p1 AND last_name=@p2`,
+			N: `SELECT 'a:b:c' || first_name, ':ABC:_:' FROM person WHERE first_name=:first_name AND last_name=:last_name`,
 			V: []string{"first_name", "last_name"},
 		},
 		{
@@ -166,7 +166,7 @@ func TestNamedQueries(t *testing.T) {
 		test.Error(err)
 
 		ns, err = db.PrepareNamed(`
-			SELECT first_name, last_name, email 
+			SELECT first_name, last_name, email
 			FROM person WHERE first_name=:first_name AND email=:email`)
 		test.Error(err)
 


### PR DESCRIPTION
To ignore comments, understand Unicode, and have fewer false positives.

This doesn't meet the original contract at the moment. The original expected any colon to be doubled up to be escaped. The double-colon (`::` -> `:`) wasn't strictly necessary but seemed to be as a result of not properly parsing string literals and comments.

It's probably worth maintaining backward compatibility but having to double-colon could trip up someone new to the package.

There's also likely more cases of how string literals can be defined based on the driver. This implementation understands Postgres.

Related issues:
https://github.com/jmoiron/sqlx/issues/394
https://github.com/jmoiron/sqlx/issues/368
https://github.com/jmoiron/sqlx/issues/304
https://github.com/jmoiron/sqlx/issues/302
https://github.com/jmoiron/sqlx/issues/206
https://github.com/jmoiron/sqlx/issues/166

This one can be done fairly easily too:
https://github.com/jmoiron/sqlx/issues/350
