### PR TITLE
Closes #583

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -29,7 +29,7 @@ func BindType(driverName string) int {
 		return QUESTION
 	case "sqlite3":
 		return QUESTION
-	case "oci8", "ora", "goracle":
+	case "oci8", "ora", "goracle", "godror":
 		return NAMED
 	case "sqlserver":
 		return AT


### PR DESCRIPTION
small fix for godror support after goracle package name changed while goracle is deprecated because of naming (trademark) issues.