### PR TITLE
Bump github.com/go-sql-driver/mysql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/jmoiron/sqlx
 
 require (
-	github.com/go-sql-driver/mysql v1.4.0
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-sqlite3 v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
-github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=


### PR DESCRIPTION
While trying to understand why my project pulled in
`google.golang.org/appengine/cloudsql` indirectly, I noticed that it's pulled in
through this library's dependency on `github.com/go-sql-driver/mysql`.

``` shell
$ go mod why -m google.golang.org/appengine
# google.golang.org/appengine
github.com/mpolden/zdns/sql
github.com/jmoiron/sqlx
github.com/jmoiron/sqlx.test
github.com/go-sql-driver/mysql
google.golang.org/appengine/cloudsql
```

However, I then noticed that a newer version of the dependency removes
`google.golang.org/appengine/cloudsql` as it's obsolete: https://github.com/go-sql-driver/mysql/pull/1007.