### PR TITLE
Added NamedSelect and NamedGet APIs

### DIFF
--- a/named.go
+++ b/named.go
@@ -411,3 +411,32 @@ func NamedExec(e Ext, query string, arg interface{}) (sql.Result, error) {
 	}
 	return e.Exec(q, args...)
 }
+
+// NamedSelect binds a named query and then runs Query on the result using the
+// provided Ext (sqlx.Tx, sql.DB) and StructScans each row
+// into dest, which must be a slice.  If the slice elements are scannable, then
+// the result set must have only one column.  Otherwise, StructScan is used.
+// The *sql.Rows are closed automatically.
+func NamedSelect(e Ext, dest interface{}, query string, arg interface{}) error {
+	rows, err := NamedQuery(e, query, arg)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	return scanAll(rows, dest, false)
+}
+
+// NamedGet binds a named query and then runs Query on the result using the
+// provided Ext (sqlx.Tx, sql.DB) and StructScan the row into dest.
+// The *sql.Rows are closed automatically.
+func NamedGet(e Ext, dest interface{}, query string, arg interface{}) error {
+	rows, err := NamedQuery(e, query, arg)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		return rows.StructScan(dest)
+	}
+	return nil
+}

--- a/sqlx.go
+++ b/sqlx.go
@@ -321,11 +321,24 @@ func (db *DB) Select(dest interface{}, query string, args ...interface{}) error 
 	return Select(db, dest, query, args...)
 }
 
+// NamedSelect using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+func (db *DB) NamedSelect(dest interface{}, query string, arg interface{}) error {
+	return NamedSelect(db, dest, query, arg)
+}
+
 // Get using this DB.
 // Any placeholder parameters are replaced with supplied args.
 // An error is returned if the result set is empty.
 func (db *DB) Get(dest interface{}, query string, args ...interface{}) error {
 	return Get(db, dest, query, args...)
+}
+
+// Get using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+// An error is returned if the result set is empty.
+func (db *DB) NamedGet(dest interface{}, query string, arg map[string]interface{}) error {
+	return NamedGet(db, dest, query, arg)
 }
 
 // MustBegin starts a transaction, and panics on error.  Returns an *sqlx.Tx instead
@@ -425,6 +438,12 @@ func (tx *Tx) NamedExec(query string, arg interface{}) (sql.Result, error) {
 // Any placeholder parameters are replaced with supplied args.
 func (tx *Tx) Select(dest interface{}, query string, args ...interface{}) error {
 	return Select(tx, dest, query, args...)
+}
+
+// NamedSelect a named query within a transaction.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedSelect(dest interface{}, query string, arg interface{}) error {
+	return NamedSelect(tx, dest, query, arg)
 }
 
 // Queryx within a transaction.


### PR DESCRIPTION
NamedSelect and NamedGet APIs to be consistent with Select and Get variants were missing. 

Kindly consider this merge request.