### PR TITLE
Replace bindArgs to bindAnyArgs to support map

### DIFF
--- a/named.go
+++ b/named.go
@@ -244,7 +244,7 @@ func bindArray(bindType int, query string, arg interface{}, m *reflectx.Mapper) 
 	}
 	var arglist []interface{}
 	for i := 0; i < arrayLen; i++ {
-		elemArglist, err := bindArgs(names, arrayValue.Index(i).Interface(), m)
+		elemArglist, err := bindAnyArgs(names, arrayValue.Index(i).Interface(), m)
 		if err != nil {
 			return "", []interface{}{}, err
 		}


### PR DESCRIPTION
By https://github.com/jmoiron/sqlx/pull/285 , batch insert is supported.
But currently, it is failed to insert the list of map because `bindArgs` doesn't support `map`.
So replace `bindArgs` to `bindAnyArgs` in `bindArray`.

---

The other pull request to fix this bug already exists #501 but I create a new pull request in two reasons.

1. #501 isn't updated for over one year.
2. In #501 `bindArgs` is fixed but we don't have to fix `bindArgs`. To accept both of map and struct, we should use `bindAnyArgs`.
