### PR TITLE
Add missing NamedQueryContext function on slqx.Tx

### DIFF
--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -284,6 +284,12 @@ func (tx *Tx) QueryRowxContext(ctx context.Context, query string, args ...interf
 	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
 }
 
+// NamedQueryContext using this Tx.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*Rows, error) {
+	return NamedQueryContext(ctx, tx, query, arg)
+}
+
 // NamedExecContext using this Tx.
 // Any named placeholder parameters are replaced with fields from arg.
 func (tx *Tx) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {


### PR DESCRIPTION
Adds the NamedQueryContext function to the Tx object. The function
already exists on the Db object, and the supporting code for
transactions is already in place, but this function is missing from
the set of named sqlx operations.