### PR TITLE
Optimize In performance by reducing allocations for common queries

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -233,11 +233,11 @@ func appendReflectSlice(args []interface{}, v reflect.Value, vlen int) []interfa
 		args = append(args, val...)
 	case []int:
 		for i := range val {
-			args = append(args, val[i])
+			args = append(args, &val[i])
 		}
 	case []string:
 		for i := range val {
-			args = append(args, val[i])
+			args = append(args, &val[i])
 		}
 	default:
 		for si := 0; si < vlen; si++ {

--- a/bind.go
+++ b/bind.go
@@ -169,7 +169,9 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 	}
 
 	newArgs := make([]interface{}, 0, flatArgsCount)
-	buf := make([]byte, 0, len(query)+len(", ?")*flatArgsCount)
+
+	var buf strings.Builder
+	buf.Grow(len(query) + len(", ?")*flatArgsCount)
 
 	var arg, offset int
 
@@ -195,10 +197,10 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		}
 
 		// write everything up to and including our ? character
-		buf = append(buf, query[:offset+i+1]...)
+		buf.WriteString(query[:offset+i+1])
 
 		for si := 1; si < argMeta.length; si++ {
-			buf = append(buf, ", ?"...)
+			buf.WriteString(", ?")
 		}
 
 		newArgs = appendReflectSlice(newArgs, argMeta.v, argMeta.length)
@@ -209,13 +211,13 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 		offset = 0
 	}
 
-	buf = append(buf, query...)
+	buf.WriteString(query)
 
 	if arg < len(meta) {
 		return "", nil, errors.New("number of bindVars less than number arguments")
 	}
 
-	return string(buf), newArgs, nil
+	return buf.String(), newArgs, nil
 }
 
 func appendReflectSlice(args []interface{}, v reflect.Value, vlen int) []interface{} {

--- a/bind.go
+++ b/bind.go
@@ -135,7 +135,14 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 	var flatArgsCount int
 	var anySlices bool
 
-	meta := make([]argMeta, len(args))
+	var stackMeta [32]argMeta
+
+	var meta []argMeta
+	if len(args) <= len(stackMeta) {
+		meta = stackMeta[:len(args)]
+	} else {
+		meta = make([]argMeta, len(args))
+	}
 
 	for i, arg := range args {
 		if a, ok := arg.(driver.Valuer); ok {


### PR DESCRIPTION
```
name          old time/op    new time/op    delta
In-8             466ns ± 1%     328ns ± 0%  -29.69%  (p=0.000 n=10+10)
In1k-8          6.42µs ± 0%    7.49µs ± 0%  +16.73%  (p=0.000 n=8+9)
In1kInt-8       9.71µs ± 8%    8.32µs ± 0%  -14.38%  (p=0.000 n=10+10)
In1kString-8    9.86µs ± 1%    9.05µs ± 0%   -8.22%  (p=0.000 n=10+9)

name          old alloc/op   new alloc/op   delta
In-8              512B ± 0%      272B ± 0%  -46.88%  (p=0.000 n=10+10)
In1k-8          22.7kB ± 0%    19.5kB ± 0%  -14.16%  (p=0.000 n=10+10)
In1kInt-8       22.7kB ± 0%    19.5kB ± 0%  -14.16%  (p=0.000 n=10+10)
In1kString-8    22.7kB ± 0%    19.5kB ± 0%  -14.16%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
In-8              10.0 ± 0%       4.0 ± 0%  -60.00%  (p=0.000 n=10+10)
In1k-8            5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
In1kInt-8         5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
In1kString-8      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
```