### PR TITLE
Remove wrong comment in code example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ type Place struct {
 }
 
 func main() {
-    // this Pings the database trying to connect, panics on error
+    // this Pings the database trying to connect
     // use sqlx.Open() for sql.Open() semantics
     db, err := sqlx.Connect("postgres", "user=foo dbname=bar sslmode=disable")
     if err != nil {


### PR DESCRIPTION
`sqlx.Connect` doesn't panic, only `sqlx.MustConnect` does.