### PR TITLE
Add custom unmarshaller to NullJSONText

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -129,6 +129,15 @@ type NullJSONText struct {
 	Valid bool // Valid is true if JSONText is not NULL
 }
 
+// UnmarshalJSON sets *n to a copy of data
+func (n *NullJSONText) UnmarshalJSON(data []byte) error {
+	if err := n.JSONText.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	n.Valid = true
+	return nil
+}
+
 // Scan implements the Scanner interface.
 func (n *NullJSONText) Scan(value interface{}) error {
 	if value == nil {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,6 +1,10 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestGzipText(t *testing.T) {
 	g := GzippedText("Hello, world")
@@ -91,6 +95,24 @@ func TestNullJSONText(t *testing.T) {
 	}
 	if j.Valid != false {
 		t.Errorf("Expected valid to be false, but got true")
+	}
+}
+
+func TestNullJSONTextJsonMarshal(t *testing.T) {
+	jsonText := NullJSONText{JSONText: []byte(`{"some":"thing"}`), Valid: true}
+	data, err := json.Marshal(&jsonText)
+	if err != nil {
+		t.Errorf("Failed to json.Marshal NullJSONText: %s", err)
+	}
+
+	newJsonText := NullJSONText{}
+	err = json.Unmarshal(data, &newJsonText)
+	if err != nil {
+		t.Errorf("Failed to json.Unmarshal NullJSONText: %s", err)
+	}
+
+	if !reflect.DeepEqual(jsonText, newJsonText) {
+		t.Error("NullJSONText is not the same after unmarshal")
 	}
 }
 


### PR DESCRIPTION
Fixes #671 

`NullJSONText` needs to be valid after successful json unmarshalling.