### PR TITLE
Suppport "type A map[string]interface{}" in named queries

### DIFF
--- a/named.go
+++ b/named.go
@@ -383,7 +383,13 @@ func bindNamedMapper(bindType int, query string, arg interface{}, m *reflectx.Ma
 	k := t.Kind()
 	switch {
 	case k == reflect.Map && t.Key().Kind() == reflect.String:
-		return bindMap(bindType, query, arg.(map[string]interface{}))
+		var m map[string]interface{}
+		if !t.ConvertibleTo(reflect.TypeOf(m)) {
+			return "", nil, fmt.Errorf("sqlx.bindNamedMapper: unsupported map type: %T", arg)
+		}
+
+		m = reflect.ValueOf(arg).Convert(reflect.TypeOf(m)).Interface().(map[string]interface{})
+		return bindMap(bindType, query, m)
 	case k == reflect.Array || k == reflect.Slice:
 		return bindArray(bindType, query, arg, m)
 	default:


### PR DESCRIPTION
I'd like to use:

	type A map[string]interface{}

	db.NamedExec("...", A{
		"named": "val",
	})

Because typing "map[string]interface{}" is a lot of work and looks kinda
ugly.

Previously this would panic, as the type assertion didn't work. So use
reflection to convert it to map[string]interface{} if possible, and
return a nicer error if not.