### PR TITLE
merge #501 to trunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@ _testmain.go
 *.exe
 tags
 environ
-
-.idea

--- a/named.go
+++ b/named.go
@@ -157,10 +157,6 @@ func bindAnyArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interfa
 // type, given a list of names to pull out of the struct.  Used by public
 // BindStruct interface.
 func bindArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{}, error) {
-	if maparg, ok := arg.(map[string]interface{}); ok {
-		return bindMapArgs(names, maparg)
-	}
-
 	arglist := make([]interface{}, 0, len(names))
 
 	// grab the indirected value of arg
@@ -206,7 +202,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 		return "", []interface{}{}, err
 	}
 
-	arglist, err := bindArgs(names, arg, m)
+	arglist, err := bindAnyArgs(names, arg, m)
 	if err != nil {
 		return "", []interface{}{}, err
 	}

--- a/named.go
+++ b/named.go
@@ -146,8 +146,22 @@ func prepareNamed(p namedPreparer, query string) (*NamedStmt, error) {
 	}, nil
 }
 
+// convertMapStringInterface attempts to convert v to map[string]interface{}.
+// Unlike v.(map[string]interface{}), this function works on named types that
+// are convertible to map[string]interface{} as well.
+func convertMapStringInterface(v interface{}) (map[string]interface{}, bool) {
+	var m map[string]interface{}
+	mtype := reflect.TypeOf(m)
+	t := reflect.TypeOf(v)
+	if !t.ConvertibleTo(mtype) {
+		return nil, false
+	}
+	return reflect.ValueOf(v).Convert(mtype).Interface().(map[string]interface{}), true
+
+}
+
 func bindAnyArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{}, error) {
-	if maparg, ok := arg.(map[string]interface{}); ok {
+	if maparg, ok := convertMapStringInterface(arg); ok {
 		return bindMapArgs(names, maparg)
 	}
 	return bindArgs(names, arg, m)
@@ -383,12 +397,10 @@ func bindNamedMapper(bindType int, query string, arg interface{}, m *reflectx.Ma
 	k := t.Kind()
 	switch {
 	case k == reflect.Map && t.Key().Kind() == reflect.String:
-		var m map[string]interface{}
-		if !t.ConvertibleTo(reflect.TypeOf(m)) {
+		m, ok := convertMapStringInterface(arg)
+		if !ok {
 			return "", nil, fmt.Errorf("sqlx.bindNamedMapper: unsupported map type: %T", arg)
 		}
-
-		m = reflect.ValueOf(arg).Convert(reflect.TypeOf(m)).Interface().(map[string]interface{})
 		return bindMap(bindType, query, m)
 	case k == reflect.Array || k == reflect.Slice:
 		return bindArray(bindType, query, arg, m)

--- a/named_test.go
+++ b/named_test.go
@@ -217,6 +217,18 @@ func TestNamedQueries(t *testing.T) {
 			VALUES (:first_name, :last_name, :email)`, slsMap)
 		test.Error(err)
 
+		type A map[string]interface{}
+
+		typedMap := []A{
+			{"first_name": "Ardie", "last_name": "Savea", "email": "asavea@ab.co.nz"},
+			{"first_name": "Sonny Bill", "last_name": "Williams", "email": "sbw@ab.co.nz"},
+			{"first_name": "Ngani", "last_name": "Laumape", "email": "nlaumape@ab.co.nz"},
+		}
+
+		_, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
+			VALUES (:first_name, :last_name, :email)`, typedMap)
+		test.Error(err)
+
 		for _, p := range sls {
 			dest := Person{}
 			err = db.Get(&dest, db.Rebind("SELECT * FROM person WHERE email=?"), p.Email)


### PR DESCRIPTION
This builds on #501, which extended batch insertion using named exec to work
with `map[string]interface{}` types as well as struct types.  It extends
builds upon another PR that added the ability for sqlx to accept named
map types that were convertible to `map[string]interface{}`, and adds a
test for the bulk insert case.