### PR TITLE
bump lib/pq ftom 1.2 to 1.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.10
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/lib/pq v1.2.0
+	github.com/lib/pq v1.10.0
 	github.com/mattn/go-sqlite3 v1.14.6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
-github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
+github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=


### PR DESCRIPTION
I'm seeing "broken pipe" errors when working with CRDB using sqlx.
The issue seems to be the db driver conns become stale when tcp connections were disconnected.

It happens more often when the DB is behind a proxy.  In our cases, the pods were proxied by the envoy sidecar.

There were other instances on the community reporting similar issues, and took different workaround by sending periodic dummy queries in app as keepalive, prolonging proxy idle timeout, or shortening the lifetime of db conns.

This has been reported and fixed in the lib/pq in v1.9+

https://github.com/lib/pq/pull/1013

Other reference:

https://github.com/lib/pq/issues/723
https://github.com/lib/pq/issues/897
https://github.com/lib/pq/issues/870

https://github.com/grafana/grafana/issues/29957