### PR TITLE
NamedExec Bulk Insert Fix

### DIFF
--- a/named_test.go
+++ b/named_test.go
@@ -202,7 +202,10 @@ func TestNamedQueries(t *testing.T) {
 			{FirstName: "Ngani", LastName: "Laumape", Email: "nlaumape@ab.co.nz"},
 		}
 
-		insert := fmt.Sprintf("INSERT INTO person (first_name, last_name, email, added_at) VALUES (:first_name, :last_name, :email, %v)\n", now)
+		insert := fmt.Sprintf(
+			"INSERT INTO person (first_name, last_name, email, added_at) VALUES (:first_name, :last_name, :email, %v)\n",
+			now,
+		)
 		_, err = db.NamedExec(insert, sls)
 		test.Error(err)
 
@@ -214,7 +217,7 @@ func TestNamedQueries(t *testing.T) {
 		}
 
 		_, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
-			VALUES (:first_name, :last_name, :email) `, slsMap)
+			VALUES (:first_name, :last_name, :email) ;--`, slsMap)
 		test.Error(err)
 
 		type A map[string]interface{}
@@ -226,7 +229,7 @@ func TestNamedQueries(t *testing.T) {
 		}
 
 		_, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
-			VALUES (:first_name, :last_name, :email) `, typedMap)
+			VALUES (:first_name, :last_name, :email) ;--`, typedMap)
 		test.Error(err)
 
 		for _, p := range sls {

--- a/named_test.go
+++ b/named_test.go
@@ -3,6 +3,7 @@ package sqlx
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"testing"
 )
 
@@ -352,4 +353,17 @@ func TestFixBounds(t *testing.T) {
 		})
 	}
 
+	t.Run("regex changed", func(t *testing.T) {
+		var valueBracketRegChanged = regexp.MustCompile(`(VALUES)\s+(\([^(]*.[^(]\))`)
+		saveRegexp := valueBracketReg
+		defer func() {
+			valueBracketReg = saveRegexp
+		}()
+		valueBracketReg = valueBracketRegChanged
+
+		res := fixBound("VALUES (:a, :b)", 2)
+		if res != "VALUES (:a, :b)" {
+			t.Errorf("changed regex should return string")
+		}
+	})
 }


### PR DESCRIPTION
This change-set is how I addressed the issues of bulk inserts not being handled cleanly when they're not at the end of the query.

It works by first adding `VALUES` to the expression (not sure if this is universally applicable to all supported SQL dialects) then adding a submatch to the regular expression for the fields we want to repeat.  Using the submatch, we're able to repeat the fields that we're concerned with to expand the insertion parameters.

Likely? Fixes #657, #694, #705, #709, #712, #713 ?