### PR TITLE
Add NamedQueryContext to Tx

### DIFF
--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -316,6 +316,12 @@ func (tx *Tx) PrepareNamedContext(ctx context.Context, query string) (*NamedStmt
 	return prepareNamedContext(ctx, tx, query)
 }
 
+// NamedQueryContext using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*Rows, error) {
+	return NamedQueryContext(ctx, tx, query, arg)
+}
+
 // MustExecContext runs MustExecContext within a transaction.
 // Any placeholder parameters are replaced with supplied args.
 func (tx *Tx) MustExecContext(ctx context.Context, query string, args ...interface{}) sql.Result {

--- a/sqlx_context_test.go
+++ b/sqlx_context_test.go
@@ -806,6 +806,25 @@ func TestUsageContext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		rows, err := tx.NamedQueryContext(ctx, "SELECT * FROM person WHERE first_name=:first", map[string]interface{}{"first": "Bin"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ben := &Person{}
+		for rows.Next() {
+			err = rows.StructScan(ben)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ben.FirstName != "Bin" {
+				t.Fatal("Expected first name of `Bin`, got " + ben.FirstName)
+			}
+			if ben.LastName != "Smuth" {
+				t.Fatal("Expected first name of `Smuth`, got " + ben.LastName)
+			}
+		}
+
 		tstmt2 := tx.Stmtx(stmt2)
 		row2 := tstmt2.QueryRowx("Jason")
 		err = row2.StructScan(&jason)
@@ -879,7 +898,7 @@ func TestUsageContext(t *testing.T) {
 			t.Errorf("Expected the right telcodes, got %#v", places)
 		}
 
-		rows, err := db.QueryxContext(ctx, "SELECT * FROM place")
+		rows, err = db.QueryxContext(ctx, "SELECT * FROM place")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -939,7 +958,7 @@ func TestUsageContext(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ben := &Person{}
+		ben = &Person{}
 		for rows.Next() {
 			err = rows.StructScan(ben)
 			if err != nil {


### PR DESCRIPTION
This change adds the NamedQueryContext method on Transactions to match calls on the Database directly.  This allows the use of `DB` and `Tx` objects more interchangeably in consuming codebases.

I totally recognize that this exact change has been proposed and many PRs with the addition have been submitted (#348 #373 #448) but they all lacked tests.  This PR also includes those changes and hopefully resolves #447 .