### PR TITLE
Fix the default binds for a 'godror' driver

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -24,7 +24,7 @@ const (
 var defaultBinds = map[int][]string{
 	DOLLAR:   []string{"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
 	QUESTION: []string{"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
-	NAMED:    []string{"oci8", "ora", "goracle"},
+	NAMED:    []string{"oci8", "ora", "goracle", "godror"},
 	AT:       []string{"sqlserver"},
 }
 


### PR DESCRIPTION
**Description**
Fix for the issue for an oracle driver https://github.com/godror/godror

This code didn't work
```
        query, args, _ := sqlx.In('select * from user where id in (?)', idList)
        q := oracleDb.Rebind(query)
	err = oracleDb.SelectContext(ctx, &dtos, q, args...)
	if err != nil {
		return nil, err
	}
```