### PR TITLE
Fix Bulk Insert: Single Column and MySQL earlier upsert syntax

### DIFF
--- a/named.go
+++ b/named.go
@@ -245,7 +245,7 @@ func findMatchingClosingBracketIndex(s string) int {
 func fixBound(bound string, loop int) string {
 	loc := valuesReg.FindStringIndex(bound)
 	// defensive guard when "VALUES (...)" not found
-	if len(loc) < 1 {
+	if len(loc) < 2 {
 		return bound
 	}
 

--- a/named.go
+++ b/named.go
@@ -224,13 +224,13 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valueBracketReg = regexp.MustCompile(`(?i)VALUES\s*(\([^(]*.[^(]\))`)
+var valueBracketReg = regexp.MustCompile(`(?i)VALUES\s*(\((?:[^(]|\([^(]*\))*\))`)
 
 func fixBound(bound string, loop int) string {
 
 	loc := valueBracketReg.FindAllStringSubmatchIndex(bound, -1)
-	// Either no VALUES () found or more than one found??
-	if len(loc) != 1 {
+	// defensive guard when "VALUES (...)" not found
+	if len(loc) < 1 {
 		return bound
 	}
 	// defensive guard. loc should be len 4 representing the starting and

--- a/named.go
+++ b/named.go
@@ -224,29 +224,47 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valueBracketReg = regexp.MustCompile(`(?i)VALUES\s*(\((?:[^(]|\([^(]*\))*\))`)
+var valuesReg = regexp.MustCompile(`(?i)VALUES\s*\(`)
+
+func findMatchingClosingBracketIndex(s string) int {
+	count := 0
+	for i, ch := range s {
+		if ch == '(' {
+			count++
+		}
+		if ch == ')' {
+			count--
+			if count == 0 {
+				return i
+			}
+		}
+	}
+	return 0
+}
 
 func fixBound(bound string, loop int) string {
-
-	loc := valueBracketReg.FindAllStringSubmatchIndex(bound, -1)
+	loc := valuesReg.FindStringIndex(bound)
 	// defensive guard when "VALUES (...)" not found
 	if len(loc) < 1 {
 		return bound
 	}
-	// defensive guard. loc should be len 4 representing the starting and
-	// ending index for the whole regex match and the starting + ending
-	// index for the single inside group
-	if len(loc[0]) != 4 {
+
+	openingBracketIndex := loc[1] - 1
+	index := findMatchingClosingBracketIndex(bound[openingBracketIndex:])
+	// defensive guard. must have closing bracket
+	if index == 0 {
 		return bound
 	}
+	closingBracketIndex := openingBracketIndex + index + 1
+
 	var buffer bytes.Buffer
 
-	buffer.WriteString(bound[0:loc[0][1]])
+	buffer.WriteString(bound[0:closingBracketIndex])
 	for i := 0; i < loop-1; i++ {
 		buffer.WriteString(",")
-		buffer.WriteString(bound[loc[0][2]:loc[0][3]])
+		buffer.WriteString(bound[openingBracketIndex:closingBracketIndex])
 	}
-	buffer.WriteString(bound[loc[0][1]:])
+	buffer.WriteString(bound[closingBracketIndex:])
 	return buffer.String()
 }
 

--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0

--- a/named_test.go
+++ b/named_test.go
@@ -391,6 +391,37 @@ func TestFixBounds(t *testing.T) {
 			expect: `INSERT INTO table_values (a, b) VALUES (:a, :b),(:a, :b)`,
 			loop:   2,
 		},
+		{
+			name: `multiline indented query`,
+			query: `INSERT INTO foo (
+		a,
+		b,
+		c,
+		d
+	) VALUES (
+		:name,
+		:age,
+		:first,
+		:last
+	)`,
+			expect: `INSERT INTO foo (
+		a,
+		b,
+		c,
+		d
+	) VALUES (
+		:name,
+		:age,
+		:first,
+		:last
+	),(
+		:name,
+		:age,
+		:first,
+		:last
+	)`,
+			loop: 2,
+		},
 	}
 
 	for _, tc := range table {

--- a/named_test.go
+++ b/named_test.go
@@ -385,6 +385,12 @@ func TestFixBounds(t *testing.T) {
 			expect: `INSERT INTO foo (a, b) VALUES (:a, YEAR(NOW())`,
 			loop:   2,
 		},
+		{
+			name:   `table with "values" at the end`,
+			query:  `INSERT INTO table_values (a, b) VALUES (:a, :b)`,
+			expect: `INSERT INTO table_values (a, b) VALUES (:a, :b),(:a, :b)`,
+			loop:   2,
+		},
 	}
 
 	for _, tc := range table {


### PR DESCRIPTION
This change handle the case of using single column in "VALUES(...)".
And allow using VALUES in "INSERT ... ON DUPLICATE KEY UPDATE ..." kind of queries,  e.g issue https://github.com/jmoiron/sqlx/issues/722
Possible fixes for https://github.com/jmoiron/sqlx/issues/701 https://github.com/jmoiron/sqlx/issues/695 https://github.com/jmoiron/sqlx/issues/694