### PR TITLE
Update sqlx.go

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -1,6 +1,7 @@
 package sqlx
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -337,6 +338,15 @@ func (db *DB) MustBegin() *Tx {
 // Beginx begins a transaction and returns an *sqlx.Tx instead of an *sql.Tx.
 func (db *DB) Beginx() (*Tx, error) {
 	tx, err := db.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	return &Tx{Tx: tx, driverName: db.driverName, unsafe: db.unsafe, Mapper: db.Mapper}, err
+}
+
+// Beginx begins a transaction and returns an *sqlx.Tx instead of an *sql.Tx.
+func (db *DB) BeginTxx(opts *sql.TxOptions) (*Tx, error) {
+	tx, err := db.DB.BeginTx(context.Background(), opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds the possibility to pass arguments to sql.BeginTx()

Name sounds a bit sketchy, but since all the other methods add "x" to the end of the "database/sql" variant names, I did the same.

Feel free to change this as needed.

Closes #751 