### PR TITLE
FIX cloning arguments on "join"

### DIFF
--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`[\(\)]\s*(?i)VALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0


### PR DESCRIPTION
https://github.com/jmoiron/sqlx/issues/753

The project made the transition from version 1.2.4 to version 1.3.4.

Cases with arguments cloning in the "join" request stopped working

Example:

```sql
SELECT t_1.code_1, t_1.code_2 , t_1.name, t_1.age
FROM public.table_name t_1
INNER JOIN (
    VALUES (:code_1, :code_2)
) t_2 (code_1, code_2) ON
    t_2.code_1 = t_1.code_1 AND t_2.code_2 = t_1.code_2
```

```go
args := struct{
    Code1 string `db:"code_1"`
    Code2 string `db:"code_2"`
}{
    {"v1", "v1"},  {"v2", "v2"},
}
```

Expected Result:

```sql
SELECT t_1.code_1, t_1.code_2 , t_1.name, t_1.age
FROM public.table_name t_1
INNER JOIN (
    VALUES ($1, $2),($3, $4)
) t_2 (code_1, code_2) ON
    t_2.code_1 = t_1.code_1 AND t_2.code_2 = t_1.code_2
```

Actual Result:

```sql
SELECT t_1.code_1, t_1.code_2 , t_1.name, t_1.age
FROM public.table_name t_1
INNER JOIN (
    VALUES ($1, $2)
) t_2 (code_1, code_2) ON
    t_2.code_1 = t_1.code_1 AND t_2.code_2 = t_1.code_2
```


__Solution to the problem__

Add one more parenthesis before VALUES 
```go
// named.go
var valuesReg = regexp.MustCompile(`[\(\)]\s*(?i)VALUES\s*\(`)
````

test case
```go
// named_test.go

func TestFixBounds(t *testing.T) {
     table := []struct {
         name, query, expect string
         loop                int
    }{
         {
             name:   `query with "join" generated table`,
             query:  `
                 SELECT 
                     t_1.code_values, t_2.name, t_2.age, t_2.first, t_2.last  
                 FROM public.table_1 t_1 
                 INNER JOIN 
                     (VALUES (:v_code, :v_name, :v_age, :v_first, :v_last)) 
                     t_2 (code, name, age, first, last)
                 ON
                     t_1.code_values = t_2.code
             `,
             expect: `
                 SELECT
                     t_1.code_values, t_2.name, t_2.age, t_2.first, t_2.last  
                 FROM public.table_1 t_1 
                 INNER JOIN 
                     (VALUES (:v_code, :v_name, :v_age, :v_first, :v_last),(:v_code, :v_name, :v_age, :v_first, :v_last)) 
                     t_2 (code, name, age, first, last)
                 ON
                     t_1.code_values = t_2.code
             `,
             loop:   2,
         },
    }
}

```






