### PR TITLE
Add oracle to defaultBinds

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -24,7 +24,7 @@ const (
 var defaultBinds = map[int][]string{
 	DOLLAR:   []string{"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
 	QUESTION: []string{"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
-	NAMED:    []string{"oci8", "ora", "goracle", "godror"},
+	NAMED:    []string{"oci8", "ora", "goracle", "godror", "oracle"},
 	AT:       []string{"sqlserver"},
 }
 


### PR DESCRIPTION
Add `oracle` to defaultBinds for use with https://github.com/sijms/go-ora (the only oracle driver that's pure go).