### PR TITLE
Refactored Rebind() so that it respects escaped ?'s

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -77,3 +77,117 @@ func BenchmarkBindSpeed(b *testing.B) {
 
 	})
 }
+
+func TestNewRebind(t *testing.T) {
+	var tests = []struct {
+		name     string
+		query    string
+		question string
+		dollar   string
+		named    string
+		at       string
+	}{
+		{
+			name:     "q1",
+			query:    `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			question: `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			dollar:   `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			named:    `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (:arg1, :arg2, :arg3, :arg4, :arg5, :arg6, :arg7, :arg8, :arg9, :arg10)`,
+			at:       `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10)`,
+		},
+		{
+			name:     "q2",
+			query:    `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`,
+			question: `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`,
+			dollar:   `INSERT INTO foo (a, b, c) VALUES ($1, $2, "foo"), ("Hi", $3, $4)`,
+			named:    `INSERT INTO foo (a, b, c) VALUES (:arg1, :arg2, "foo"), ("Hi", :arg3, :arg4)`,
+			at:       `INSERT INTO foo (a, b, c) VALUES (@p1, @p2, "foo"), ("Hi", @p3, @p4)`,
+		},
+		{
+			name:     "q3: question escaped",
+			query:    `SELECT * FROM test_table where id = ? AND name = 'four?'`,
+			question: `SELECT * FROM test_table where id = ? AND name = 'four?'`,
+			dollar:   `SELECT * FROM test_table where id = $1 AND name = 'four?'`,
+			named:    `SELECT * FROM test_table where id = :arg1 AND name = 'four?'`,
+			at:       `SELECT * FROM test_table where id = @p1 AND name = 'four?'`,
+		},
+		{
+			name:     "q4: escaped single quote and escaped question mark",
+			query:    `INSERT INTO test_table (name, country) VALUES ('Maybe O''Reilly?', 'US') WHERE id = ?`,
+			question: `INSERT INTO test_table (name, country) VALUES ('Maybe O''Reilly?', 'US') WHERE id = ?`,
+			dollar:   `INSERT INTO test_table (name, country) VALUES ('Maybe O''Reilly?', 'US') WHERE id = $1`,
+			named:    `INSERT INTO test_table (name, country) VALUES ('Maybe O''Reilly?', 'US') WHERE id = :arg1`,
+			at:       `INSERT INTO test_table (name, country) VALUES ('Maybe O''Reilly?', 'US') WHERE id = @p1`,
+		},
+		{
+			name:     "q5: escaped double quote and escaped question mark",
+			query:    `INSERT INTO test_table ("inches aka"" is the column name i think?") VALUES (42) WHERE id = ?`,
+			question: `INSERT INTO test_table ("inches aka"" is the column name i think?") VALUES (42) WHERE id = ?`,
+			dollar:   `INSERT INTO test_table ("inches aka"" is the column name i think?") VALUES (42) WHERE id = $1`,
+			named:    `INSERT INTO test_table ("inches aka"" is the column name i think?") VALUES (42) WHERE id = :arg1`,
+			at:       `INSERT INTO test_table ("inches aka"" is the column name i think?") VALUES (42) WHERE id = @p1`,
+		},
+		{
+			name:     "q6: backslash escaped quote and escaped question mark",
+			query:    `INSERT INTO test_table (name, country) VALUES ('Maybe O\'Reilly?', 'US') WHERE id = ?`,
+			question: `INSERT INTO test_table (name, country) VALUES ('Maybe O\'Reilly?', 'US') WHERE id = ?`,
+			dollar:   `INSERT INTO test_table (name, country) VALUES ('Maybe O\'Reilly?', 'US') WHERE id = $1`,
+			named:    `INSERT INTO test_table (name, country) VALUES ('Maybe O\'Reilly?', 'US') WHERE id = :arg1`,
+			at:       `INSERT INTO test_table (name, country) VALUES ('Maybe O\'Reilly?', 'US') WHERE id = @p1`,
+		},
+	}
+
+	for _, test := range tests {
+		q := Rebind(QUESTION, test.query)
+		if q != test.question {
+			t.Errorf("%s failed at 'question'", test.name)
+		}
+		d := Rebind(DOLLAR, test.query)
+		if d != test.dollar {
+			t.Errorf("%s failed at 'dollar'", test.name)
+		}
+		n := Rebind(NAMED, test.query)
+		if n != test.named {
+			t.Errorf("%s failed at 'named'", test.name)
+		}
+		a := Rebind(AT, test.query)
+		if a != test.at {
+			t.Errorf("%s failed at 'at'", test.name)
+		}
+	}
+}
+
+/*
+goos: linux
+goarch: amd64
+pkg: github.com/jmoiron/sqlx
+BenchmarkRebind/index-8        	 2114181	       598 ns/op
+BenchmarkRebind/new-8         	 2827218	       747 ns/op
+BenchmarkRebind/buff-8        	 1000000	      1678 ns/op
+*/
+
+func BenchmarkRebind(b *testing.B) {
+	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
+
+	b.Run("index", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rebindIndex(DOLLAR, q1)
+			rebindIndex(DOLLAR, q2)
+		}
+	})
+
+	b.Run("new", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Rebind(DOLLAR, q1)
+			Rebind(DOLLAR, q2)
+		}
+	})
+
+	b.Run("buff", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rebindBuff(DOLLAR, q1)
+			rebindBuff(DOLLAR, q2)
+		}
+	})
+}

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1316,47 +1316,6 @@ func TestDoNotPanicOnConnect(t *testing.T) {
 	}
 }
 
-func TestRebind(t *testing.T) {
-	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
-
-	s1 := Rebind(DOLLAR, q1)
-	s2 := Rebind(DOLLAR, q2)
-
-	if s1 != `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)` {
-		t.Errorf("q1 failed")
-	}
-
-	if s2 != `INSERT INTO foo (a, b, c) VALUES ($1, $2, "foo"), ("Hi", $3, $4)` {
-		t.Errorf("q2 failed")
-	}
-
-	s1 = Rebind(AT, q1)
-	s2 = Rebind(AT, q2)
-
-	if s1 != `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10)` {
-		t.Errorf("q1 failed")
-	}
-
-	if s2 != `INSERT INTO foo (a, b, c) VALUES (@p1, @p2, "foo"), ("Hi", @p3, @p4)` {
-		t.Errorf("q2 failed")
-	}
-
-	s1 = Rebind(NAMED, q1)
-	s2 = Rebind(NAMED, q2)
-
-	ex1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES ` +
-		`(:arg1, :arg2, :arg3, :arg4, :arg5, :arg6, :arg7, :arg8, :arg9, :arg10)`
-	if s1 != ex1 {
-		t.Error("q1 failed on Named params")
-	}
-
-	ex2 := `INSERT INTO foo (a, b, c) VALUES (:arg1, :arg2, "foo"), ("Hi", :arg3, :arg4)`
-	if s2 != ex2 {
-		t.Error("q2 failed on Named params")
-	}
-}
-
 func TestBindMap(t *testing.T) {
 	// Test that it works..
 	q1 := `INSERT INTO foo (a, b, c, d) VALUES (:name, :age, :first, :last)`
@@ -1826,30 +1785,6 @@ func BenchmarkIn1kString(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_, _, _ = In(q, []interface{}{"foo", vals[:], "bar"}...)
-	}
-}
-
-func BenchmarkRebind(b *testing.B) {
-	b.StopTimer()
-	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		Rebind(DOLLAR, q1)
-		Rebind(DOLLAR, q2)
-	}
-}
-
-func BenchmarkRebindBuffer(b *testing.B) {
-	b.StopTimer()
-	q1 := `INSERT INTO foo (a, b, c, d, e, f, g, h, i) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	q2 := `INSERT INTO foo (a, b, c) VALUES (?, ?, "foo"), ("Hi", ?, ?)`
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		rebindBuff(DOLLAR, q1)
-		rebindBuff(DOLLAR, q2)
 	}
 }
 


### PR DESCRIPTION
This PR addresses a `FIXME` comment I found next to the `Rebind()` function.

> FIXME: this should be able to be tolerant of escaped ?'s in queries without losing much speed, and should be to avoid confusion.

### Summary of changes

- Refactored `Rebind()` to respect `?` that are properly escaped as part of a string using single or double quotes.
- Moved existing `Rebind()` unit tests from `sqlx_test.go` to `bind_test.go`
- Refactored existing `Rebind()` unit tests to run along side the new unit tests.
- Moved `Rebind()` benchmarks to `bind_test.go` and combined them into a single benchmark function with sub-benchmarks.

### Valid Escaped ?'s

Because of the cross DBMS nature of `Rebind()` there are some ways to escape a character or string in Postgres, SQL Server, etc. that don't make sense to implement because they are not supported by all DBMS's. 

This version of `Rebind()` respects two kinds of escaped question marks: string constants, and quoted identifiers. Double an single quotes that are inside a  string constant or quoted identifier can be escaped by using a C style backslash e.g. `\"` or by using a two quotation marks e.g. `""`

**String Constants**

A `?` that is part of a valid string constant i.e. surrounded by single quotes is not replaced with a parameter placeholder e.g. `$1`.

Examples of string constant escaped `?`:

```
'foo?'
'bar\'d?'
'qux''d?'
'foo said "bar"?'
```

**Quoted Identifiers**

A `?` that is part of a valid quoted or delimited identifier i.e. surrounded by double quotes is not replaced with a parameter placeholder.

Examples of quoted identifier escaped `?`:

```

"foo?"
"bar said \"foo\"?"
"qux'd?"
"foo said ""bar""?"
```

None of the question marks in the above examples will be replaced with a parameter placeholder.

### Benchmarks

This new version of `Rebind()` is slower than the previous `strings.Index` version. However, it is faster than the `bytes.Buffer` version.

```
goos: linux
goarch: amd64
pkg: github.com/jmoiron/sqlx
BenchmarkRebind/index-8        	 2114181	       598 ns/op
BenchmarkRebind/new-8         	 2827218	       747 ns/op
BenchmarkRebind/buff-8        	 1000000	      1678 ns/op
```