### PR TITLE
add a column name mapper func

### DIFF
--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -104,7 +104,7 @@ func NewMapperFunc(tagName string, f func(string) string) *Mapper {
 // NewMapperTagColFunc returns a new mapper which contains a mapper for field names
 // AND a mapper for tag values AND a mapper for column names.  This is useful for tags
 // like json which can have values like "name,omitempty", and processing sql column
-// names to lower case for example.
+// names.
 func NewMapperTagColFunc(tagName string, mapFunc, tagMapFunc, colMapFunc func(string) string) *Mapper {
 	return &Mapper{
 		cache:      make(map[reflect.Type]*StructMap),

--- a/reflectx/reflect_test.go
+++ b/reflectx/reflect_test.go
@@ -286,6 +286,38 @@ func TestInlineStruct(t *testing.T) {
 	}
 }
 
+func TestColMapFunc(t *testing.T) {
+	m := NewMapperTagColFunc("db", strings.ToLower, nil, strings.ToLower)
+
+	type Employee struct {
+		FirstName string
+		ID        int
+	}
+	type Boss Employee
+	type person struct {
+		Employee `db:"employee"`
+		Boss     `db:"boss"`
+	}
+	// employees columns: (employee.firstName employee.id boss.firstName boss.id)
+
+	em := person{Employee: Employee{FirstName: "Joe", ID: 2}, Boss: Boss{FirstName: "Dick", ID: 1}}
+	ev := reflect.ValueOf(em)
+
+	fields := m.TypeMap(reflect.TypeOf(em))
+	if len(fields.Index) != 6 {
+		t.Errorf("Expecting 6 fields")
+	}
+
+	v := m.FieldByName(ev, "employee.firstName")
+	if v.Interface().(string) != em.Employee.FirstName {
+		t.Errorf("Expecting %s, got %s", em.Employee.FirstName, v.Interface().(string))
+	}
+	v = m.FieldByName(ev, "boss.id")
+	if ival(v) != em.Boss.ID {
+		t.Errorf("Expecting %v, got %v", em.Boss.ID, ival(v))
+	}
+}
+
 func TestRecursiveStruct(t *testing.T) {
 	type Person struct {
 		Parent *Person


### PR DESCRIPTION
it may be generally helpful to process column names when mapping, similar to how field names and tag names can be preprocessed in the mapper. This is an optional additive change.

having to add a db or json tag to every struct field just to lower case the first character of the field feels very redundant, when we could just ToLower both the field name and the column name to match.