### PR TITLE
Reduce allocations in fixBound

### DIFF
--- a/named.go
+++ b/named.go
@@ -257,7 +257,8 @@ func fixBound(bound string, loop int) string {
 	}
 	closingBracketIndex := openingBracketIndex + index + 1
 
-	var buffer bytes.Buffer
+	length := closingBracketIndex + (loop-1)*(closingBracketIndex-openingBracketIndex+1) + len(bound) - closingBracketIndex
+	buffer := bytes.NewBuffer(make([]byte, 0, length))
 
 	buffer.WriteString(bound[0:closingBracketIndex])
 	for i := 0; i < loop-1; i++ {

--- a/named_test.go
+++ b/named_test.go
@@ -433,3 +433,21 @@ func TestFixBounds(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkFixBound10(b *testing.B) {
+	query := `INSERT INTO foo (a,b) VALUES(:a, :b)`
+	loop := 10
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		fixBound(query, loop)
+	}
+}
+
+func BenchmarkFixBound100(b *testing.B) {
+	query := `INSERT INTO foo (a,b) VALUES(:a, :b)`
+	loop := 100
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		fixBound(query, loop)
+	}
+}


### PR DESCRIPTION
Reduces allocations by initializing `bytes.Buffer` with correct target capacity.

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkFixBound10-8      346           324           -6.42%
BenchmarkFixBound100-8     1410          1170          -17.02%

benchmark                  old allocs     new allocs     delta
BenchmarkFixBound10-8      4              3              -25.00%
BenchmarkFixBound100-8     7              3              -57.14%

benchmark                  old bytes     new bytes     delta
BenchmarkFixBound10-8      354           273           -22.88%
BenchmarkFixBound100-8     3294          2082          -36.79%
```