### PR TITLE
fix: batch insert bind for ptr slice

### DIFF
--- a/named.go
+++ b/named.go
@@ -277,7 +277,7 @@ func bindArray(bindType int, query string, arg interface{}, m *reflectx.Mapper) 
 	if err != nil {
 		return "", []interface{}{}, err
 	}
-	arrayValue := reflect.ValueOf(arg)
+	arrayValue := reflect.Indirect(reflect.ValueOf(arg))
 	arrayLen := arrayValue.Len()
 	if arrayLen == 0 {
 		return "", []interface{}{}, fmt.Errorf("length of array is 0: %#v", arg)
@@ -421,6 +421,11 @@ func Named(query string, arg interface{}) (string, []interface{}, error) {
 func bindNamedMapper(bindType int, query string, arg interface{}, m *reflectx.Mapper) (string, []interface{}, error) {
 	t := reflect.TypeOf(arg)
 	k := t.Kind()
+
+	if k == reflect.Ptr {
+		k = t.Elem().Kind()
+	}
+
 	switch {
 	case k == reflect.Map && t.Key().Kind() == reflect.String:
 		m, ok := convertMapStringInterface(arg)

--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valueBracketReg = regexp.MustCompile(`VALUES\s+(\([^(]*.[^(]\))`)
+var valueBracketReg = regexp.MustCompile(`(?i:VALUES)\s*(\([^(]*.[^(]\))`)
 
 func fixBound(bound string, loop int) string {
 	loc := valueBracketReg.FindAllStringSubmatchIndex(bound, -1)

--- a/named_test.go
+++ b/named_test.go
@@ -342,6 +342,24 @@ func TestFixBounds(t *testing.T) {
 			expect: `INSERT INTO foo (a,b,c,d) VALUES (:name, :age, :first, :last) VALUES (:name, :age, :first, :last)`,
 			loop:   2,
 		},
+		{
+			name:   `lowercase`,
+			query:  `INSERT INTO foo (a,b,c,d) values (:name, :age, :first, :last)`,
+			expect: `INSERT INTO foo (a,b,c,d) values (:name, :age, :first, :last),(:name, :age, :first, :last)`,
+			loop:   2,
+		},
+		{
+			name:   `not blank space`,
+			query:  `INSERT INTO foo (a,b,c,d) VALUES(:name, :age, :first, :last)`,
+			expect: `INSERT INTO foo (a,b,c,d) VALUES(:name, :age, :first, :last),(:name, :age, :first, :last)`,
+			loop:   2,
+		},
+		{
+			name:   `capital letter`,
+			query:  `INSERT INTO foo (a,b,c,d) Values(:name, :age, :first, :last)`,
+			expect: `INSERT INTO foo (a,b,c,d) Values(:name, :age, :first, :last),(:name, :age, :first, :last)`,
+			loop:   2,
+		},
 	}
 
 	for _, tc := range table {
@@ -354,7 +372,7 @@ func TestFixBounds(t *testing.T) {
 	}
 
 	t.Run("regex changed", func(t *testing.T) {
-		var valueBracketRegChanged = regexp.MustCompile(`(VALUES)\s+(\([^(]*.[^(]\))`)
+		var valueBracketRegChanged = regexp.MustCompile(`(?i:VALUES)\s*(\([^(]*.[^(]\))`)
 		saveRegexp := valueBracketReg
 		defer func() {
 			valueBracketReg = saveRegexp
@@ -362,7 +380,7 @@ func TestFixBounds(t *testing.T) {
 		valueBracketReg = valueBracketRegChanged
 
 		res := fixBound("VALUES (:a, :b)", 2)
-		if res != "VALUES (:a, :b)" {
+		if res != "VALUES (:a, :b),(:a, :b)" {
 			t.Errorf("changed regex should return string")
 		}
 	})

--- a/named_test.go
+++ b/named_test.go
@@ -211,6 +211,10 @@ func TestNamedQueries(t *testing.T) {
 		_, err = db.NamedExec(insert, sls)
 		test.Error(err)
 
+		// and test ptr batch inserts
+		_, err = db.NamedExec(insert, &sls)
+		test.Error(err)
+
 		// test map batch inserts
 		slsMap := []map[string]interface{}{
 			{"first_name": "Ardie", "last_name": "Savea", "email": "asavea@ab.co.nz"},


### PR DESCRIPTION
Variables behave inconsistently when using batch inserts

```
  people := []Person{}
  db.Select(&people, "SELECT * FROM person ORDER BY first_name ASC")   <---- this is ptr
```

```
  // batch insert with structs
  personStructs := []Person{
      {FirstName: "Ardie", LastName: "Savea", Email: "asavea@ab.co.nz"},
      {FirstName: "Sonny Bill", LastName: "Williams", Email: "sbw@ab.co.nz"},
      {FirstName: "Ngani", LastName: "Laumape", Email: "nlaumape@ab.co.nz"},
  }

  _, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
      VALUES (:first_name, :last_name, :email)`, personStructs) <----- this not ptr
```

So, support  batch insert used ptr slice
```
  // batch insert with structs
  personStructs := []Person{
      {FirstName: "Ardie", LastName: "Savea", Email: "asavea@ab.co.nz"},
      {FirstName: "Sonny Bill", LastName: "Williams", Email: "sbw@ab.co.nz"},
      {FirstName: "Ngani", LastName: "Laumape", Email: "nlaumape@ab.co.nz"},
  }

  _, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
      VALUES (:first_name, :last_name, :email)`, &personStructs) <----- this ptr
```
