### PR TITLE
fix: bindArray on SELECT from VALUES list

### DIFF
--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`[\)|\(]\s*(?i)VALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0

--- a/named_test.go
+++ b/named_test.go
@@ -392,6 +392,18 @@ func TestFixBounds(t *testing.T) {
 			loop:   2,
 		},
 		{
+			name:   `table named "values"`,
+			query:  `INSERT INTO values (a, b) VALUES (:a, :b)`,
+			expect: `INSERT INTO values (a, b) VALUES (:a, :b),(:a, :b)`,
+			loop:   2,
+		},
+		{
+			name:   `select from values list`,
+			query:  `SELECT * FROM (VALUES (:a, :b))`,
+			expect: `SELECT * FROM (VALUES (:a, :b),(:a, :b))`,
+			loop:   2,
+		},
+		{
 			name: `multiline indented query`,
 			query: `INSERT INTO foo (
 		a,
@@ -428,7 +440,7 @@ func TestFixBounds(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := fixBound(tc.query, tc.loop)
 			if res != tc.expect {
-				t.Errorf("mismatched results")
+				t.Errorf("mismatched results. Expected: %s, got: %s", tc.expect, res)
 			}
 		})
 	}


### PR DESCRIPTION
- `fixBound` currently assumes named var in VALUES is only from INSERT
- `bindArray `is not populating the right number of placeholders

Ideally the regex should be something like: `(?<!(?i)into)\W+(?i)VALUES\s*\(` but Golang regex doesn't support look around