### PR TITLE
[Row] Fix: db connection leakage in Err method

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -234,6 +234,7 @@ func (r *Row) ColumnTypes() ([]*sql.ColumnType, error) {
 
 // Err returns the error encountered while scanning.
 func (r *Row) Err() error {
+	defer r.rows.Close()
 	return r.err
 }
 


### PR DESCRIPTION
**Issue Outline**: there is db connection leakage happening here, if someone makes a DB calls and doesn't really call any of the Scan methods where `rows` generally being closed via calling `rows.Close()` method and directly calls the `Err()` method over `Row` instance just to check the err in that case `rows` cursor connection is still alive and hence it leaks the db connection.

**Proposed Solution**: explicitly close the `rows` in the Err() method too so that it can be made sure that if someone directly calls this method without using any scanning method, still connection would be closed.
