### PR TITLE
Fix regexp for named queries

### DIFF
--- a/named.go
+++ b/named.go
@@ -224,7 +224,9 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`[\)\(]\s*(?i)VALUES\s*\(`)
+
+// var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0

--- a/named_test.go
+++ b/named_test.go
@@ -422,13 +422,19 @@ func TestFixBounds(t *testing.T) {
 	)`,
 			loop: 2,
 		},
+		{
+			name:   `select with "values" and no insert`,
+			query:  `SELECT a, b FROM (VALUES (:a, :b)) x (a, b)`,
+			expect: `SELECT a, b FROM (VALUES (:a, :b),(:a, :b)) x (a, b)`,
+			loop:   2,
+		},
 	}
 
 	for _, tc := range table {
 		t.Run(tc.name, func(t *testing.T) {
 			res := fixBound(tc.query, tc.loop)
 			if res != tc.expect {
-				t.Errorf("mismatched results")
+				t.Errorf("mismatched results, got \"%s\" but expected \"%s\"", res, tc.expect)
 			}
 		})
 	}


### PR DESCRIPTION
Fixing https://github.com/jmoiron/sqlx/issues/772 #796

The current regexp expects `VALUE (:a, :b)` to come after a closing bracket. But in some cases `VALUES (:a, :b)` is embedded in a `FROM` statement.

In this fix, I consider the named queries to allow both `(` and `)` char before the `VALUE` statement.
