### PR TITLE
FIX: unicode named params problem

### DIFF
--- a/named_test.go
+++ b/named_test.go
@@ -56,13 +56,15 @@ func TestCompileQuery(t *testing.T) {
 		/* This unicode awareness test sadly fails, because of our byte-wise worldview.
 		 * We could certainly iterate by Rune instead, though it's a great deal slower,
 		 * it's probably the RightWay(tm)
+		 */
 		{
 			Q: `INSERT INTO foo (a,b,c,d) VALUES (:あ, :b, :キコ, :名前)`,
 			R: `INSERT INTO foo (a,b,c,d) VALUES (?, ?, ?, ?)`,
 			D: `INSERT INTO foo (a,b,c,d) VALUES ($1, $2, $3, $4)`,
-			N: []string{"name", "age", "first", "last"},
+			N: `INSERT INTO foo (a,b,c,d) VALUES (:あ, :b, :キコ, :名前)`,
+			T: `INSERT INTO foo (a,b,c,d) VALUES (@p1, @p2, @p3, @p4)`,
+			V: []string{"あ", "b", "キコ", "名前"},
 		},
-		*/
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
The "compiledNamedQuery" function WAS NOT safe for Unicode named params, as evidenced by a failed test.

Specifying a string range in runes instead of bytes is inconvenient and slow, so I changed it to detect when a single rune is split into multiple bytes. This allows failing tests to pass. Please provide this fix to users outside the ASCII code area, including us Japanese.