### PR TITLE
Add missing Tx.NamedQueryContext

### DIFF
--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -358,6 +358,12 @@ func (tx *Tx) NamedExecContext(ctx context.Context, query string, arg interface{
 	return NamedExecContext(ctx, tx, query, arg)
 }
 
+// NamedQueryContext within a transaction.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*Rows, error) {
+	return NamedQueryContext(ctx, tx, query, arg)
+}
+
 // SelectContext using the prepared statement.
 // Any placeholder parameters are replaced with supplied args.
 func (s *Stmt) SelectContext(ctx context.Context, dest interface{}, args ...interface{}) error {


### PR DESCRIPTION
In an effort to use a postgres `INSERT ... RETURNING` stmt in a transaction, I found that there was a `(*sqlx.Tx).NamedQuery` but not a `(*sqlx.Tx).NamedQueryContext`. This PR attempts to remedy that. 