### PR TITLE
Improve error messaging for empty named parameter keys

### DIFF
--- a/named.go
+++ b/named.go
@@ -181,6 +181,9 @@ func bindArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{
 
 	err := m.TraversalsByNameFunc(v.Type(), names, func(i int, t []int) error {
 		if len(t) == 0 {
+			if names[i] == "" {
+				return fmt.Errorf("sqlx.bindArgs: empty named parameter at index %d in %#v", i, names)
+			}
 			return fmt.Errorf("could not find name %s in %#v", names[i], arg)
 		}
 
@@ -197,7 +200,10 @@ func bindArgs(names []string, arg interface{}, m *reflectx.Mapper) ([]interface{
 func bindMapArgs(names []string, arg map[string]interface{}) ([]interface{}, error) {
 	arglist := make([]interface{}, 0, len(names))
 
-	for _, name := range names {
+	for i, name := range names {
+		if name == "" {
+			return arglist, fmt.Errorf("sqlx.bindMapArgs: empty named parameter at index %d in %#v", i, names)
+		}
 		val, ok := arg[name]
 		if !ok {
 			return arglist, fmt.Errorf("could not find name %s in %#v", name, arg)

--- a/named_test.go
+++ b/named_test.go
@@ -3,6 +3,7 @@ package sqlx
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -299,6 +300,15 @@ func TestNamedQueries(t *testing.T) {
 			t.Errorf("expected %s, got %s", sl.Email, p2.Email)
 		}
 
+		_, _, err = db.BindNamed("SELECT * FROM person WHERE id=:id /*TODO: handle accidental colon in named query*/", struct{ID int `db:"id"`}{1})
+		if err == nil || !strings.Contains(err.Error(), "sqlx.bindArgs: empty named parameter") {
+			t.Error("Expected an empty named parameter error with struct arg.")
+		}
+
+		_, _, err = db.BindNamed("SELECT * FROM person WHERE id=:id /*TODO: handle accidental colon in named query*/", map[string]interface{}{"id": 1})
+		if err == nil || !strings.Contains(err.Error(), "sqlx.bindMapArgs: empty named parameter") {
+			t.Error("Expected an empty named parameter error with map arg.")
+		}
 	})
 }
 


### PR DESCRIPTION
This PR is to improve the error message returned by sqlx when a named bind parameter name is empty, example:  `SELECT * FROM person WHERE id=:id -- TODO: Improve stuff`

Instead of `could not find name  in...` the output is `sqlx.bindArgs: empty named parameter at index 1 in []string{"id", ""}`

