### PR TITLE
Add azuresql driver bind

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -22,10 +22,10 @@ const (
 )
 
 var defaultBinds = map[int][]string{
-	DOLLAR:   []string{"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
-	QUESTION: []string{"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
-	NAMED:    []string{"oci8", "ora", "goracle", "godror"},
-	AT:       []string{"sqlserver"},
+	DOLLAR:   {"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
+	QUESTION: {"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
+	NAMED:    {"oci8", "ora", "goracle", "godror"},
+	AT:       {"sqlserver", "azuresql"},
 }
 
 var binds sync.Map


### PR DESCRIPTION
When accessing azure managed sql server via Azure AD for authentication we need to use [`azuresql` driver](https://github.com/microsoft/go-mssqldb/blob/main/azuread/driver.go#L15)

So the behavior of `azuresql` is the same of `sqlserver`. 
But in our default bind doesn't include that driver name

This PR added it to default bind with AT