### PR TITLE
Add binds for pgx driver w/ explicit version in name

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -22,7 +22,7 @@ const (
 )
 
 var defaultBinds = map[int][]string{
-	DOLLAR:   {"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
+	DOLLAR:   {"postgres", "pgx", "pgx/v4", "pgx/v5", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
 	QUESTION: {"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
 	NAMED:    {"oci8", "ora", "goracle", "godror"},
 	AT:       {"sqlserver", "azuresql"},


### PR DESCRIPTION
The jackc's pgx driver does support multiple version through driver
name containing major version. This doesn't work out of the box with
named parameters.

https://github.com/jackc/pgx/issues/1480