### PR TITLE
feat: add missing methods

### DIFF
--- a/sqlx.go
+++ b/sqlx.go
@@ -77,6 +77,7 @@ type ColScanner interface {
 type Queryer interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	Queryx(query string, args ...interface{}) (*Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
 	QueryRowx(query string, args ...interface{}) *Row
 }
 
@@ -561,6 +562,10 @@ func (q *qStmt) Queryx(query string, args ...interface{}) (*Rows, error) {
 		return nil, err
 	}
 	return &Rows{Rows: r, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}, err
+}
+
+func (q *qStmt) QueryRow(query string, args ...interface{}) *sql.Row {
+	return q.Stmt.QueryRow(args...)
 }
 
 func (q *qStmt) QueryRowx(query string, args ...interface{}) *Row {

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -26,6 +26,7 @@ func ConnectContext(ctx context.Context, driverName, dataSourceName string) (*DB
 type QueryerContext interface {
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryxContext(ctx context.Context, query string, args ...interface{}) (*Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 	QueryRowxContext(ctx context.Context, query string, args ...interface{}) *Row
 }
 
@@ -409,6 +410,10 @@ func (q *qStmt) QueryxContext(ctx context.Context, query string, args ...interfa
 		return nil, err
 	}
 	return &Rows{Rows: r, unsafe: q.Stmt.unsafe, Mapper: q.Stmt.Mapper}, err
+}
+
+func (q *Stmt) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return q.Stmt.QueryRowContext(ctx, args...)
 }
 
 func (q *qStmt) QueryRowxContext(ctx context.Context, query string, args ...interface{}) *Row {

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -353,6 +353,12 @@ func (tx *Tx) QueryRowxContext(ctx context.Context, query string, args ...interf
 	return &Row{rows: rows, err: err, unsafe: tx.unsafe, Mapper: tx.Mapper}
 }
 
+// NamedQueryContext using this DB.
+// Any named placeholder parameters are replaced with fields from arg.
+func (tx *Tx) NamedQueryContext(ctx context.Context, query string, arg interface{}) (*Rows, error) {
+	return NamedQueryContext(ctx, tx, query, arg)
+}
+
 // NamedExecContext using this Tx.
 // Any named placeholder parameters are replaced with fields from arg.
 func (tx *Tx) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {


### PR DESCRIPTION
This PR adds some missing methods to flesh out interfaces and make `DB` and `Tx` have more of a shared interface.

This opens up the possibility of creating a common interface that represents either one so that functions can be written that execute queries without needing to know if they're being run within a transaction or not.

- [ ] TODO: Add unit tests.
_I wasn't sure how the tests were organized for this project.  If there's a specific test function you'd like them added to (or a new one), let me know._

📌 Long-term (future PR), I'd like to create an interface (or a few) that represent the remaining shared query-related methods, and then one interface that represents either a `DB` or `Tx`.  These are the additional methods not represented in another interface right now:
* `Get(dest interface{}, query string, args ...interface{}) error`
* `GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error`
* `MustExec(query string, args ...interface{}) sql.Result`
* `MustExecContext(ctx context.Context, query string, args ...interface{}) sql.Result`
* `NamedExec(query string, arg interface{}) (sql.Result, error)`
* `NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)`
* `NamedQuery(query string, arg interface{}) (*sqlx.Rows, error)`
* `NamedQueryContext(ctx context.Context, query string, arg interface{}) (*sqlx.Rows, error)`
* `PrepareNamed(query string) (*sqlx.NamedStmt, error)`
* `PrepareNamedContext(ctx context.Context, query string) (*sqlx.NamedStmt, error)`
* `Preparex(query string) (*sqlx.Stmt, error)`
* `PreparexContext(ctx context.Context, query string) (*sqlx.Stmt, error)`
* `Select(dest interface{}, query string, args ...interface{}) error`
* `SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error`