### PR TITLE
allow empty slice for 'in' queries

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -175,10 +175,6 @@ func In(query string, args ...interface{}) (string, []interface{}, error) {
 
 			anySlices = true
 			flatArgsCount += meta[i].length
-
-			if meta[i].length == 0 {
-				return "", nil, errors.New("empty slice passed to 'in' query")
-			}
 		} else {
 			meta[i].i = arg
 			flatArgsCount++


### PR DESCRIPTION
Can be useful for queries like below.

```
db.Exec("DELETE FROM server_config WHERE server_id = ? AND config_id NOT IN (?)", srvID, configIDs)
```