### PR TITLE
Add support for clickhouse settings in NamedExec's fixBounds

### DIFF
--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`\)\s*(?i)(?:SETTINGS\s+.*)?\s*VALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0

--- a/named_test.go
+++ b/named_test.go
@@ -422,13 +422,19 @@ func TestFixBounds(t *testing.T) {
 	)`,
 			loop: 2,
 		},
+		{
+			name:   `clickhouse settings`,
+			query:  `INSERT INTO foo (a,b) settings async_insert=1, wait_for_async_insert=1 VALUES(:a, :b)`,
+			expect: `INSERT INTO foo (a,b) settings async_insert=1, wait_for_async_insert=1 VALUES(:a, :b),(:a, :b)`,
+			loop:   2,
+		},
 	}
 
 	for _, tc := range table {
 		t.Run(tc.name, func(t *testing.T) {
 			res := fixBound(tc.query, tc.loop)
 			if res != tc.expect {
-				t.Errorf("mismatched results")
+				t.Errorf("mismatched results got %v", res)
 			}
 		})
 	}


### PR DESCRIPTION
Hi folks, im having trouble with bulk inserts into clickhouse. NamedExec queries are only getting the first value in the array.

This PR fixes the issue by extending the regex to support settings.

Eg this test case fails, with only joe getting inserted, not sally.
```go
func TestInsertNamedBulk(t *testing.T) {
	_, err := db.Exec(schema)
	assert.NoError(t, err)
	defer cleanup(t)

	// Insert data
	_, err = db.NamedExec(
		`insert into users (id, name, age)
		SETTINGS async_insert=1, wait_for_async_insert=1
		values
		(:id, :name, :age)`,
		[]map[string]any{
			{
				"id":   1,
				"name": "joe",
				"age":  30,
			},
			{
				"id":   2,
				"name": "sally",
				"age":  31,
			},
		})
	assert.NoError(t, err)

	users, err := findUsers()
	assert.NoError(t, err)
	assert.Equal(t, []User{
		{ID: 1, Name: "joe", Age: 30},
		{ID: 2, Name: "sally", Age: 31},
	}, users)
}
```