### PR TITLE
Relax constraint on VALUE clause expansion

### DIFF
--- a/named.go
+++ b/named.go
@@ -224,7 +224,7 @@ func bindStruct(bindType int, query string, arg interface{}, m *reflectx.Mapper)
 	return bound, arglist, nil
 }
 
-var valuesReg = regexp.MustCompile(`\)\s*(?i)VALUES\s*\(`)
+var valuesReg = regexp.MustCompile(`(?i)\WVALUES\s*\(`)
 
 func findMatchingClosingBracketIndex(s string) int {
 	count := 0

--- a/named_test.go
+++ b/named_test.go
@@ -422,6 +422,30 @@ func TestFixBounds(t *testing.T) {
 	)`,
 			loop: 2,
 		},
+		{
+			name: "use of VALUES not for insert",
+			query: `
+UPDATE t
+SET
+  foo = u.foo,
+  bar = u.bar
+FROM (
+  VALUES (:id, :foo, :bar)
+) AS u(id, foo, bar)
+WHERE t.id = u.id
+`,
+			expect: `
+UPDATE t
+SET
+  foo = u.foo,
+  bar = u.bar
+FROM (
+  VALUES (:id, :foo, :bar),(:id, :foo, :bar)
+) AS u(id, foo, bar)
+WHERE t.id = u.id
+`,
+			loop: 2,
+		},
 	}
 
 	for _, tc := range table {


### PR DESCRIPTION
sqlx has a handy feature that is mentioned in the README examples under the name "batch insert". I believe it comes from #285.

```
    personStructs := []Person{
        {FirstName: "Ardie", LastName: "Savea", Email: "asavea@ab.co.nz"},
        {FirstName: "Sonny Bill", LastName: "Williams", Email: "sbw@ab.co.nz"},
        {FirstName: "Ngani", LastName: "Laumape", Email: "nlaumape@ab.co.nz"},
    }

    _, err = db.NamedExec(`INSERT INTO person (first_name, last_name, email)
        VALUES (:first_name, :last_name, :email)`, personStructs)
```

Essentially, it recognizes `VALUES (:first_name, :last_name, :email)` and expands it out into a VALUES clause of the appropriate length.

It's called "batch insert" because the purpose is to support these kinds of INSERT queries. However, INSERT is not the only case where `VALUES` is used. Suppose I want to update several different rows at once using a single query. I could do this:

```
UPDATE t
SET
  first_name = u.first_name,
  last_name = u.last_name
FROM (
  VALUES (123, "Sonny Will", "Billiams"),
         (234, "Ngani", "Smith")
) AS u(id, first_name, last_name)
WHERE t.id = u.id
```

(I'm used to Postgres; not sure if this works in other DBs or not.)

I'd like to be able to use sqlx's VALUES-expansion for this as well:

```
UPDATE t
SET
  first_name = u.first_name,
  last_name = u.last_name
FROM (
  VALUES (:id, :first_name, :last_name)
) AS u(id, first_name, last_name)
WHERE t.id = u.id
```

The only reason this doesn't work today is that the regex which recognizes the VALUES list expect it to follow a `)`, as in an INSERT query.

This is related to a prior fix in this area: #734.