### PR TITLE
feat: Expose scanning any/all without enforcing struct

### DIFF
--- a/named.go
+++ b/named.go
@@ -105,7 +105,7 @@ func (n *NamedStmt) Select(dest interface{}, arg interface{}) error {
 	}
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
-	return scanAll(rows, dest, false)
+	return ScanAll(rows, dest, false)
 }
 
 // Get using this NamedStmt

--- a/named_context.go
+++ b/named_context.go
@@ -100,7 +100,7 @@ func (n *NamedStmt) SelectContext(ctx context.Context, dest interface{}, arg int
 	}
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
-	return scanAll(rows, dest, false)
+	return ScanAll(rows, dest, false)
 }
 
 // GetContext using this NamedStmt

--- a/sqlx.go
+++ b/sqlx.go
@@ -785,9 +785,7 @@ func ScanSingleRow(r ColScanner, dest interface{}, structOnly bool) error {
 
 	var m *reflectx.Mapper
 	switch rows := r.(type) {
-	case *Rows:
-		m = rows.Mapper
-	case *Row:
+	case *Rows, *Row:
 		m = rows.Mapper
 	default:
 		m = mapper()

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -59,7 +59,7 @@ func SelectContext(ctx context.Context, q QueryerContext, dest interface{}, quer
 	}
 	// if something happens here, we want to make sure the rows are Closed
 	defer rows.Close()
-	return scanAll(rows, dest, false)
+	return ScanAll(rows, dest, false)
 }
 
 // PreparexContext prepares a statement.

--- a/sqlx_context_test.go
+++ b/sqlx_context_test.go
@@ -1052,7 +1052,7 @@ func TestUsageContext(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		err = scanAll(rows, &sdest, false)
+		err = ScanAll(rows, &sdest, false)
 		if err != nil {
 			t.Error(err)
 		}

--- a/sqlx_test.go
+++ b/sqlx_test.go
@@ -1235,7 +1235,7 @@ func TestUsage(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		err = scanAll(rows, &sdest, false)
+		err = ScanAll(rows, &sdest, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1920,6 +1920,412 @@ func TestSelectReset(t *testing.T) {
 		// non-nil slice.
 		if emptyDest != nil {
 			t.Error("Expected emptyDest to be nil")
+		}
+	})
+}
+
+func TestScanSingleRowStruct(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test scanning into a struct
+		rows, err := db.Queryx("SELECT first_name, last_name, email FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+
+		if !rows.Next() {
+			t.Fatal("Expected at least one row")
+		}
+
+		var p Person
+		err = ScanSingleRow(rows, &p, false)
+		if err != nil {
+			t.Errorf("ScanSingleRow failed: %v", err)
+		}
+
+		if p.FirstName != "Jason" {
+			t.Errorf("Expected FirstName to be 'Jason', got '%s'", p.FirstName)
+		}
+		if p.LastName != "Moiron" {
+			t.Errorf("Expected LastName to be 'Moiron', got '%s'", p.LastName)
+		}
+		if p.Email != "jmoiron@jmoiron.net" {
+			t.Errorf("Expected Email to be 'jmoiron@jmoiron.net', got '%s'", p.Email)
+		}
+	})
+}
+
+func TestScanSingleRowScannableType(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test scanning into a scannable type (single column)
+		rows, err := db.Queryx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows.Next() {
+			rows.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var firstName string
+		err = ScanSingleRow(rows, &firstName, false)
+		rows.Close()
+		if err != nil {
+			t.Errorf("ScanSingleRow failed: %v", err)
+		}
+
+		if firstName != "Jason" {
+			t.Errorf("Expected firstName to be 'Jason', got '%s'", firstName)
+		}
+
+		// Test scanning another string column
+		rows2, err := db.Queryx("SELECT last_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows2.Next() {
+			rows2.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var lastName string
+		err = ScanSingleRow(rows2, &lastName, false)
+		rows2.Close()
+		if err != nil {
+			t.Errorf("ScanSingleRow failed: %v", err)
+		}
+
+		if lastName != "Moiron" {
+			t.Errorf("Expected lastName to be 'Moiron', got '%s'", lastName)
+		}
+	})
+}
+
+func TestScanSingleRowErrors(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		rows, err := db.Queryx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows.Next() {
+			rows.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		// Test non-pointer destination
+		var name string
+		err = ScanSingleRow(rows, name, false)
+		if err == nil {
+			t.Error("Expected error when passing non-pointer destination, but got nil")
+		}
+		if !strings.Contains(err.Error(), "must pass a pointer") {
+			t.Errorf("Expected error about non-pointer, got: %v", err)
+		}
+
+		// Test nil pointer destination
+		err = ScanSingleRow(rows, (*string)(nil), false)
+		rows.Close()
+		if err == nil {
+			t.Error("Expected error when passing nil pointer, but got nil")
+		}
+		if !strings.Contains(err.Error(), "nil pointer passed") {
+			t.Errorf("Expected error about nil pointer, got: %v", err)
+		}
+
+		// Test scannable type with multiple columns
+		rows2, err := db.Queryx("SELECT first_name, last_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows2.Next() {
+			rows2.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var singleString string
+		err = ScanSingleRow(rows2, &singleString, false)
+		rows2.Close()
+		if err == nil {
+			t.Error("Expected error when scanning multiple columns into single scannable type, but got nil")
+		}
+		if !strings.Contains(err.Error(), "with >1 columns") {
+			t.Errorf("Expected error about multiple columns, got: %v", err)
+		}
+
+		// Test missing fields in struct (this may or may not error depending on unsafe mode)
+		type PartialPerson struct {
+			FirstName string `db:"first_name"`
+			// Missing last_name field
+		}
+
+		rows3, err := db.Queryx("SELECT first_name, last_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows3.Next() {
+			rows3.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var pp PartialPerson
+		err = ScanSingleRow(rows3, &pp, false)
+		rows3.Close()
+		// This should work in unsafe mode, but may error in safe mode depending on implementation
+		// We'll just verify that if there's an error, it's about missing fields
+		if err != nil && !strings.Contains(err.Error(), "missing destination name") {
+			t.Errorf("Unexpected error type: %v", err)
+		}
+	})
+}
+
+func TestScanSingleRowStructOnly(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test structOnly=true with struct - should succeed
+		rows, err := db.Queryx("SELECT first_name, last_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows.Next() {
+			rows.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var p Person
+		err = ScanSingleRow(rows, &p, true)
+		rows.Close()
+		if err != nil {
+			t.Errorf("ScanSingleRow with structOnly=true should work for struct, got error: %v", err)
+		}
+
+		if p.FirstName != "Jason" {
+			t.Errorf("Expected FirstName to be 'Jason', got '%s'", p.FirstName)
+		}
+
+		// Test structOnly=true with scannable type - should error
+		rows2, err := db.Queryx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows2.Next() {
+			rows2.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var name string
+		err = ScanSingleRow(rows2, &name, true)
+		rows2.Close()
+		if err == nil {
+			t.Error("Expected error when using structOnly=true with scannable type, but got nil")
+		}
+		// The error should be a structOnly error
+		if !strings.Contains(err.Error(), "expected struct but got") {
+			t.Errorf("Expected structOnly error, got: %v", err)
+		}
+
+		// Test structOnly=false with scannable type - should succeed
+		rows3, err := db.Queryx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !rows3.Next() {
+			rows3.Close()
+			t.Fatal("Expected at least one row")
+		}
+
+		var name2 string
+		err = ScanSingleRow(rows3, &name2, false)
+		rows3.Close()
+		if err != nil {
+			t.Errorf("ScanSingleRow with structOnly=false should work for scannable type, got error: %v", err)
+		}
+
+		if name2 != "Jason" {
+			t.Errorf("Expected name2 to be 'Jason', got '%s'", name2)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowx(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test scanning into a struct using QueryRowx
+		row := db.QueryRowx("SELECT first_name, last_name, email FROM person WHERE first_name = 'Jason'")
+		
+		var p Person
+		err := ScanSingleRow(row, &p, false)
+		if err != nil {
+			t.Errorf("ScanSingleRow with QueryRowx failed: %v", err)
+		}
+
+		if p.FirstName != "Jason" {
+			t.Errorf("Expected FirstName to be 'Jason', got '%s'", p.FirstName)
+		}
+		if p.LastName != "Moiron" {
+			t.Errorf("Expected LastName to be 'Moiron', got '%s'", p.LastName)
+		}
+		if p.Email != "jmoiron@jmoiron.net" {
+			t.Errorf("Expected Email to be 'jmoiron@jmoiron.net', got '%s'", p.Email)
+		}
+
+		// Test scanning into a scannable type using QueryRowx
+		row2 := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'John'")
+		
+		var firstName string
+		err = ScanSingleRow(row2, &firstName, false)
+		if err != nil {
+			t.Errorf("ScanSingleRow with QueryRowx for scannable type failed: %v", err)
+		}
+
+		if firstName != "John" {
+			t.Errorf("Expected firstName to be 'John', got '%s'", firstName)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxNonPointer(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test non-pointer destination with QueryRowx
+		row := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		
+		var name string
+		err := ScanSingleRow(row, name, false)
+		if err == nil {
+			t.Error("Expected error when passing non-pointer destination to QueryRowx ScanSingleRow, but got nil")
+		}
+		if !strings.Contains(err.Error(), "must pass a pointer") {
+			t.Errorf("Expected error about non-pointer with QueryRowx, got: %v", err)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxNilPointer(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test nil pointer destination with QueryRowx
+		row := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		
+		err := ScanSingleRow(row, (*string)(nil), false)
+		if err == nil {
+			t.Error("Expected error when passing nil pointer to QueryRowx ScanSingleRow, but got nil")
+		}
+		if !strings.Contains(err.Error(), "nil pointer passed") {
+			t.Errorf("Expected error about nil pointer with QueryRowx, got: %v", err)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxMultipleColumns(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test scannable type with multiple columns using QueryRowx
+		row := db.QueryRowx("SELECT first_name, last_name FROM person WHERE first_name = 'Jason'")
+		
+		var singleString string
+		err := ScanSingleRow(row, &singleString, false)
+		if err == nil {
+			t.Error("Expected error when scanning multiple columns into single scannable type with QueryRowx, but got nil")
+		}
+		if !strings.Contains(err.Error(), "with >1 columns") {
+			t.Errorf("Expected error about multiple columns with QueryRowx, got: %v", err)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxStructOnlyTrue(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test structOnly=true with struct using QueryRowx - should succeed
+		row := db.QueryRowx("SELECT first_name, last_name FROM person WHERE first_name = 'Jason'")
+		
+		var p Person
+		err := ScanSingleRow(row, &p, true)
+		if err != nil {
+			t.Errorf("ScanSingleRow with QueryRowx and structOnly=true should work for struct, got error: %v", err)
+		}
+
+		if p.FirstName != "Jason" {
+			t.Errorf("Expected FirstName to be 'Jason', got '%s'", p.FirstName)
+		}
+		if p.LastName != "Moiron" {
+			t.Errorf("Expected LastName to be 'Moiron', got '%s'", p.LastName)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxStructOnlyError(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test structOnly=true with scannable type using QueryRowx - should error
+		row := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'Jason'")
+		
+		var name string
+		err := ScanSingleRow(row, &name, true)
+		if err == nil {
+			t.Error("Expected error when using structOnly=true with scannable type and QueryRowx, but got nil")
+		}
+		// The error should be a structOnly error
+		if !strings.Contains(err.Error(), "expected struct but got") {
+			t.Errorf("Expected structOnly error with QueryRowx, got: %v", err)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxStructOnlyFalse(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test structOnly=false with scannable type using QueryRowx - should succeed
+		row := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'John'")
+		
+		var name string
+		err := ScanSingleRow(row, &name, false)
+		if err != nil {
+			t.Errorf("ScanSingleRow with QueryRowx and structOnly=false should work for scannable type, got error: %v", err)
+		}
+
+		if name != "John" {
+			t.Errorf("Expected name to be 'John', got '%s'", name)
+		}
+	})
+}
+
+func TestScanSingleRowWithQueryRowxNoRows(t *testing.T) {
+	RunWithSchema(defaultSchema, t, func(db *DB, t *testing.T, now string) {
+		loadDefaultFixture(db, t)
+
+		// Test QueryRowx with no matching rows - should return sql.ErrNoRows
+		row := db.QueryRowx("SELECT first_name FROM person WHERE first_name = 'NonExistent'")
+		
+		var name string
+		err := ScanSingleRow(row, &name, false)
+		if err == nil {
+			t.Error("Expected sql.ErrNoRows when no rows match QueryRowx, but got nil")
+		}
+		if err.Error() != "sql: no rows in result set" {
+			t.Errorf("Expected sql.ErrNoRows with QueryRowx, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## High level

Exposes two functions - `ScanAll` and `ScanSingleRow` that can be used with a `Rows` instance to safely/easily bind to a `dest` that's a struct _or_ a scannable. 

## Use case

The reason for this addition is, I'm writing an wrapper around `*sqlx.DB` that essentially prepends a GTID check into a multi-statement. I'm trying to support `GetContext` and `SelectContext` so that they can be called without any difference to the function signature when using the wrapper (and no need for awareness of wrapper logic at all).

The code I've written so far that's running into this blocker is:
- prepends a separate query to the incoming query
- using `QueryxContext` to get the results of the multi-statement queries
- reading the first result, doing things, then moving onto the second (`NextResultSet`)
- once I'm onto the second, I basically want to bind to `dest` just like the standard `GetContext` would
- [blocker] however, if I use something like `rows.StructScan(dest)`, it panics if the provided `dest` isn't a struct

psuedo-code
```
func (g *DB) GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
    ...
    multiStatementQuery, combinedArgs := prependQuery(query)
    rows, err := g.d.QueryxContext(ctx, multiStatementQuery, combinedArgs...)
    ...
    defer rows.Close()
    ... 
    rows.Scan(xxx) // read the first query results
    ... 
    rows.NextResultSet() // move to next result set
    ... 
    rows.StructScan(dest) // this is what fails, when a caller passes in a scannable to this wrapper
}
```

With this PR, the end state would be that I can swap my last line (`rows.StructScan(dest)`) to `sqlx.ScanSingleRow(rows, dest, false)`. 

I have the same issue with my `SelectContext` function where i'll need `sqlx.ScanAll`. 

## Details

This PR exposes `scanAll` as a public function. The function has been unmodified, other than updating the casing (so that it's public) and removing the sentence in the comment about the desirability to make it public 🙂 all calls to `scanAll` have been updated to `ScanAll`.

Additionally, this PR exposes a function called `ScanSingleRow` which is a subset of the existing `scanAny` function. It was slightly modified to support `Rows` or `Row`, but should not introduce a functional difference from the existing implementation. 

Neither of these changes are breaking changes. They essentially expose the "scan x" functionality so that they can be called without needing to reflect on the dest before choosing to call something like `StructScan`. 

## Additional Context

If it means anything at all, this change is for code I'm writing @GitHub. I'm hoping not to have to keep a `sqlx` fork just for this delta. If there's feedback in terms of naming, or, if you'd prefer this to somehow be put under a subdirectory/package, I'm happy to iterate here! If there's a way to accomplish this with the existing code, without reinventing a chunk of sqlx reflection/scanning, I'm happy to close this PR.